### PR TITLE
Console I/O support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,35 +15,119 @@ KickC support will be coming soon (or sooner, if someone would like to port the 
 
 ## FAT32 File Access
 
+```
 void closeall(void);
 unsigned char open(char *filename);
 void close(unsigned char fd);
 unsigned short read512(unsigned char fd,unsigned char *buffer);
+```
 
-To use these functions you must include fileio.h
+To use these functions you must include `fileio.h`
 
 ## FAT32 Directory Access
 
-Functions similar to the Posix equivalents are provided. Key differences are that unsigned char *
-is used instead of DIR * for the directory handle, and readdir() returns a pointer to a m65_dirent struct,
-instead of dirent struct.
+Functions similar to the POSIX equivalents are provided. Key differences are that `unsigned char *`
+is used instead of `DIR *` for the directory handle, and `readdir()` returns a pointer to a `m65_dirent` struct,
+instead of `dirent`struct.
 
 As file handle support is still partial in the hypervisor, only one directory or file can be safely open at any
-point in time, and it is wise to call closeall() before opening any file or directory.
+point in time, and it is wise to call `closeall()` before opening any file or directory.
 
-opendir() currently takes no path as input, as the Hypervisor can only work on a single directory at the moment.
+`opendir()` currently takes no path as input, as the Hypervisor can only work on a single directory at the moment.
 Support for sub-directories will come in the fullness of time.
 
+```
 unsigned char *opendir(void);
 m65_dirent *readdir(unsigned char *dir_handle);
 void closedir(unsigned char *dir_handle);
+```
 
-To use these functions you must include dirent.h
+To use these functions you must include `dirent.h` 
 
 ## Clock Access
 
-getrtc(struct m65_tm *) and setrtc(struct struct m65_tm *) allow retrieval and setting of the real-time-clock
+`getrtc(struct m65_tm *)` and `setrtc(struct struct m65_tm *)` allow retrieval and setting of the real-time-clock
 (RTC) using structures broadly similar to the posix tm structure.
 These routines abstract the different model RTCs that exist on different MEGA65 hardware targets.
 
-To use these functions you must include time.h
+To use these functions you must include `time.h`
+
+## Text Console I/O
+
+The `conio.h` file is projected to support all MEGA65 text features in the future.  
+
+In this version, remember to set VIC-III extended character attributes register in $D031 if you want to use the attribute function calls.
+
+Note that **no bounds checking is done in any function due to lazyness and/or performance reasons. Be careful**.
+
+
+```
+
+ /* Clear the text screen. Color RAM will be cleared with current text color */
+void clrscr(); 
+
+ /* Returns the dimensions of the text mode screen.  
+    Ignores any virtual chargen dimensions */
+void fastcall screensize(unsigned char* width, unsigned char* height);
+
+/* Set the current border color */
+void fastcall bordercolor(unsigned char c);
+
+/* Set the current screen color */
+void fastcall bgcolor(unsigned char c);
+
+/* Set the current text color*/
+void fastcall textcolor(unsigned char c);
+
+/* Enable the reverse attribute */
+void fastcall revers(unsigned char enable);
+
+/* Enable the highlight attribute */
+void fastcall highlight(unsigned char enable);
+
+/* Enable the highlight attribute */
+void fastcall blink(unsigned char enable);
+
+/* Enable the highlight attribute */
+void fastcall underline(unsigned char enable);
+
+/* Put cursor at X,Y. 
+   The function does not check for screen bounds! */
+void fastcall gotoxy(unsigned char x, unsigned char y);
+
+/* Put cursor at column X. The function does not check for screen bounds */
+void fastcall gotox(unsigned char x);
+
+/* Put cursor at row Y. The function does not check for screen bounds */
+void fastcall gotoy(unsigned char x);
+
+/* Enable cursor */
+void fastcall cursor(unsigned char enable);
+
+/* Output a single character at current position */
+void fastcall cputc(unsigned char c);
+
+/* Set color of character cell */
+void ccellcolor(unsigned char x, unsigned char y, unsigned char c);
+
+/* Output an hex-formatted number at current position with prec digits */
+void cputhex(long n, unsigned char prec);
+
+/* Output a decimal number at current position with padding digits */
+void cputdec(long n, unsigned char padding, unsigned char leadingZ);
+
+/* Output a string at current position */
+void fastcall cputs(const char* s);
+
+/* Output a string at x,y */
+void cputsxy (unsigned char x, unsigned char y, const char* s);
+
+/* Output a character at x,y */
+void cputcxy (unsigned char x, unsigned char y, char c);
+
+/* Wait until a character is in the keyboard buffer and return it */
+unsigned char fastcall cgetc (void);
+
+/* Return the character in the keyboard buffer, if any */
+unsigned char fastcall kbhit (void);
+```

--- a/cc65/include/conio.h
+++ b/cc65/include/conio.h
@@ -1,9 +1,23 @@
-/*
- * A minimalistic CONIO.H style header  for the Mega65 libC
- * 
- * Author: Hernán Di Pietro <hernan.di.pietro@gmail.com>
- * Date  : 2020-06-28
- */
+/*  CONIO.H style Text mode support  for the Mega65 libC
+
+    Copyright (c) 2020 Hernán Di Pietro
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
+    Version   0.3
+    Date      2020-06-28
+*/
 
 #ifndef M65LIBC_CONIO_H
 #define M65LIBC_CONIO_H

--- a/cc65/include/conio.h
+++ b/cc65/include/conio.h
@@ -1,0 +1,121 @@
+/*
+ * A minimalistic CONIO.H style header  for the Mega65 libC
+ * 
+ * Author: Hernán Di Pietro <hernan.di.pietro@gmail.com>
+ * Date  : 2020-06-28
+ */
+
+#ifndef M65LIBC_CONIO_H
+#define M65LIBC_CONIO_H
+
+#define VIC_BASE            0xD000UL
+#define SCREEN_ADDRESS      0x8000
+#define REG_H640            (PEEK(VIC_BASE+0x31) & 128)
+#define REG_V400            (PEEK(VIC_BASE+0x31) & 8)
+#define REG_16BITCHARSET    (PEEK(VIC_BASE + 0x54) & 1)
+#define SCREEN_RAM_BASE_B0  (PEEK(VIC_BASE + 0x60)) // LSB
+#define SCREEN_RAM_BASE_B1  (PEEK(VIC_BASE + 0x61))
+#define SCREEN_RAM_BASE_B2  (PEEK(VIC_BASE + 0x62))
+#define SCREEN_RAM_BASE_B3  (PEEK(VIC_BASE + 0x63) & 7) // upper nybble
+#define SCREEN_RAM_BASE     ( ((long)SCREEN_RAM_BASE_B3 << 24) | ((long)SCREEN_RAM_BASE_B2 << 16) | ((long)SCREEN_RAM_BASE_B1 << 8) | (SCREEN_RAM_BASE_B0) )  
+#define COLOR_RAM_BASE      0x1F800UL
+#define ATTRIB_REVERSE 0x20
+#define ATTRIB_BLINK 0x10
+#define ATTRIB_UNDERLINE 0x80
+#define ATTRIB_HIGHLIGHT 0x40
+#define COLOUR_BLACK 0
+#define COLOUR_WHITE 1
+#define COLOUR_RED 2
+#define COLOUR_CYAN 3
+#define COLOUR_PURPLE 4
+#define COLOUR_GREEN 5
+#define COLOUR_BLUE 6
+#define COLOUR_YELLOW 7
+#define COLOUR_ORANGE 8
+#define COLOUR_BROWN 9
+#define COLOUR_PINK 10
+#define COLOUR_GREY1 11
+#define COLOUR_DARKGREY 11
+#define COLOUR_GREY2 12
+#define COLOUR_GREY 12
+#define COLOUR_MEDIUMGREY 12
+#define COLOUR_LIGHTGREEN 13
+#define COLOUR_LIGHTBLUE 14
+#define COLOUR_GREY3 15
+#define COLOUR_LIGHTGREY 15
+
+ /* Clear the text screen. Color RAM will be cleared with current text color */
+void clrscr(); 
+
+ /* Returns the dimensions of the text mode screen.  
+    Ignores any virtual chargen dimensions */
+void fastcall screensize(unsigned char* width, unsigned char* height);
+
+/* Set the current border color */
+void fastcall bordercolor(unsigned char c);
+
+/* Set the current screen color */
+void fastcall bgcolor(unsigned char c);
+
+/* Set the current text color*/
+void fastcall textcolor(unsigned char c);
+
+/* Enable the reverse attribute */
+void fastcall revers(unsigned char enable);
+
+/* Enable the highlight attribute */
+void fastcall highlight(unsigned char enable);
+
+/* Enable the highlight attribute */
+void fastcall blink(unsigned char enable);
+
+/* Enable the highlight attribute */
+void fastcall underline(unsigned char enable);
+
+/* Put cursor at X,Y. 
+   The function does not check for screen bounds! */
+void fastcall gotoxy(unsigned char x, unsigned char y);
+
+/* Put cursor at column X. The function does not check for screen bounds */
+void fastcall gotox(unsigned char x);
+
+/* Put cursor at row Y. The function does not check for screen bounds */
+void fastcall gotoy(unsigned char x);
+
+/* Enable cursor */
+void fastcall cursor(unsigned char enable);
+
+/* Output a single character at current position */
+void fastcall cputc(unsigned char c);
+
+/* Set color of character cell */
+void ccellcolor(unsigned char x, unsigned char y, unsigned char c);
+
+/* Output an hex-formatted number at current position with prec digits */
+void cputhex(long n, unsigned char prec);
+
+/* Output a decimal number at current position with padding digits */
+void cputdec(long n, unsigned char padding, unsigned char leadingZ);
+
+/* Output a string at current position */
+void fastcall cputs(const char* s);
+
+/* Output a string at x,y */
+void cputsxy (unsigned char x, unsigned char y, const char* s);
+
+/* Output a character at x,y */
+void cputcxy (unsigned char x, unsigned char y, char c);
+
+/* Wait until a character is in the keyboard buffer and return it */
+unsigned char fastcall cgetc (void);
+
+/* Return the character in the keyboard buffer, if any */
+unsigned char fastcall kbhit (void);
+
+unsigned char cprintf (const char* format, ...);
+void cscanf(const char* format, ...);
+
+
+#endif //M65LIBC_CONIO_H
+
+

--- a/cc65/src/conio.c
+++ b/cc65/src/conio.c
@@ -1,0 +1,211 @@
+/*
+ * A minimalistic CONIO.H style header  for the Mega65 libC
+ * 
+ * Author    Hernán Di Pietro <hernan.di.pietro@gmail.com>
+ * Version   0.3
+ * Date      2020-06-28
+ */
+
+#include "../include/conio.h"
+#include "../include/memory.h"
+
+#define PRINTF_IN_FORMAT_SPEC    0x1
+#define PRINTF_FLAGS_LEADINGZERO 0x2
+
+static unsigned char g_curTextColor = COLOUR_WHITE;
+static unsigned char g_curAttr = 0;
+static unsigned char g_curX = 0;
+static unsigned char g_curY = 0;
+static const unsigned char hexDigits[] = { '0','1','2','3','4','5','6','7','8','9',0x41,0x42,0x43,0x44,0x45,0x46};
+
+static unsigned char strlen(const char* s)
+{
+    unsigned char len = 0;
+    while(*s++)
+        len++;
+
+    return len;
+}   
+
+void screensize(unsigned char* width, unsigned char *height)
+{
+    *width = REG_H640 ? 80 : 40;
+    *height = REG_V400 ? 50 : 25;
+}
+
+void clrscr()
+{
+    unsigned int cBytes = 0;
+    unsigned char w = 0, h = 0;
+    
+    screensize(&w, &h);
+    cBytes = (unsigned int)w * h * (REG_16BITCHARSET ? 2 : 1);
+    lfill(SCREEN_RAM_BASE, ' ', cBytes);
+    lfill(COLOR_RAM_BASE,  g_curTextColor, cBytes);
+}
+
+void bordercolor(unsigned char c)
+{
+    POKE(VIC_BASE + 0x20, c);
+}
+
+void bgcolor(unsigned char c)
+{
+    POKE(VIC_BASE + 0x21, c);
+}
+
+void textcolor(unsigned char c)
+{
+    g_curTextColor = (g_curTextColor & 0xF0) | (c & 0xf);
+}
+
+void ccellcolor(unsigned char x, unsigned char y, unsigned char c)
+{
+    unsigned char w = 0, h = 0;
+    screensize(&w, &h);
+    lpoke(COLOR_RAM_BASE + (y * (unsigned int) w) + x, c);
+}
+
+void revers(unsigned char enable)
+{
+    if (enable)
+        g_curTextColor |= ATTRIB_REVERSE;
+    else
+        g_curTextColor &= ~ATTRIB_REVERSE;
+}
+
+void highlight(unsigned char enable)
+{
+    if (enable)
+        g_curTextColor |= ATTRIB_HIGHLIGHT;
+    else
+        g_curTextColor &= ~ATTRIB_HIGHLIGHT;
+}
+
+void blink(unsigned char enable)
+{
+    if (enable)
+        g_curTextColor |= ATTRIB_BLINK;
+    else
+        g_curTextColor &= ~ATTRIB_BLINK;
+}
+
+void underline(unsigned char enable)
+{
+    if (enable)
+        g_curTextColor |= ATTRIB_UNDERLINE;
+    else
+        g_curTextColor &= ~ATTRIB_UNDERLINE;
+}
+
+void gotoxy(unsigned char x, unsigned char y)
+{
+    g_curX = x;
+    g_curY = y;
+}
+
+void gotox(unsigned char x)
+{
+    g_curX = x;
+}
+
+void gotoy(unsigned char y)
+{
+    g_curY = y;
+}
+
+void cputc(unsigned char c)
+{
+    cputcxy(g_curX, g_curY, c);
+}
+
+unsigned char cprintf (const char* fmt, ...)
+{
+    // TODO: IMPLEMENT.
+
+    // unsigned char readItems = 0;
+    // unsigned char flags = 0;
+    
+    // va_list va;
+    
+    while(*fmt)
+    {
+        cputc(*fmt++);
+    }
+}
+
+void cputhex(long n, unsigned char prec)
+{
+    unsigned char buffer[10];
+    buffer[0] = '$';
+    buffer[1] = hexDigits[(n & 0xF0000000UL) >> 28];
+    buffer[2] = hexDigits[(n & 0x0F000000UL) >> 24];
+    buffer[3] = hexDigits[(n & 0x00F00000UL) >> 20];
+    buffer[4] = hexDigits[(n & 0x000F0000UL) >> 16];
+    buffer[5] = hexDigits[(n & 0x0000F000UL) >> 12];
+    buffer[6] = hexDigits[(n & 0x00000F00UL) >> 8];
+    buffer[7] = hexDigits[(n & 0x000000F0UL) >> 4];
+    buffer[8] = hexDigits[(n & 0x0000000FUL) ];
+    buffer[9] = '\0';
+    buffer[8 - prec] = '$';
+    cputs(&buffer[8 - prec]);
+}
+
+void cputdec(long n, unsigned char padding, unsigned char leadingZeros)
+{
+    unsigned char buffer[11];
+    unsigned char rem = 0, i = 0;
+    char digit = 9;
+    buffer[10] = '\0';
+    do
+    {
+        rem = n % 10;
+        n /= 10;
+        buffer[digit--] = hexDigits[rem];
+    } while ( (digit >= 0) && (n != 0) );
+
+    while ( (digit >= 0) && (leadingZeros--))
+    {
+        buffer[digit--] = hexDigits[0];
+    }
+
+    cputs(&buffer[digit + 1]);
+}
+
+void cputs(const char *s)
+{
+    cputsxy(g_curX, g_curY, s);
+}
+
+void cputsxy(unsigned char x, unsigned char y, const char *s)
+{
+    unsigned char w = 0, h = 0, len = strlen(s);
+    screensize(&w, &h);
+    lcopy( (long) s, SCREEN_ADDRESS + (y * (unsigned int) w) + x, len);     
+    lfill(COLOR_RAM_BASE + (y * (unsigned int) w) + x, g_curTextColor, len);
+    g_curY = y + ((x + len) / w);
+    g_curX = (x + len) % w;
+}
+
+void cputcxy (unsigned char x, unsigned char y, char c)
+{
+    unsigned char w = 0, h = 0;
+    screensize(&w, &h);
+    lpoke(SCREEN_ADDRESS + (y * (unsigned int) w) + x, c);
+    lpoke(COLOR_RAM_BASE + (y * (unsigned int) w) + x, g_curTextColor);
+    g_curX = (x == w - 1) ? 0 : (x + 1);
+    g_curY = (x == w - 1) ? (y + 1) : y;
+}
+
+unsigned char cgetc (void)
+{
+    unsigned char k;
+    POKE(0xD610U,0);
+    while ((k = PEEK(0xD610U)) == 0);
+    return k;
+}
+
+unsigned char kbhit(void)
+{
+    return PEEK(0xD0610U);
+}

--- a/cc65/src/conio.c
+++ b/cc65/src/conio.c
@@ -1,10 +1,23 @@
-/*
- * A minimalistic CONIO.H style header  for the Mega65 libC
- * 
- * Author    Hernán Di Pietro <hernan.di.pietro@gmail.com>
- * Version   0.3
- * Date      2020-06-28
- */
+/*  CONIO.H style Text mode support  for the Mega65 libC
+
+    Copyright (c) 2020 Hernán Di Pietro
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
+    Version   0.3
+    Date      2020-06-28
+*/
 
 #include "../include/conio.h"
 #include "../include/memory.h"


### PR DESCRIPTION
This is my first implementation of a conio.h kind of console I/O library, like CC65 has -- and old popular "Borland" compilers  included back in the 90s.  The aim was to support the Spred65 sprite editor that I'm working on, but seems to be pretty useful to be included in the Mega65-libc, and of course to be enhanced in the future, fully supporting the MEGA65 text mode features.

The following sprite editor shot  shows the library functions rendering text in 80 column mode, with VICIII text attributes for reverse and blinking cursor.

![image](https://user-images.githubusercontent.com/4740613/86193293-efd12f00-bb21-11ea-9b71-380938e1cb4b.png)

Tested with cc65 2.18.

A straightforward function list in the README file is also provided. Thanks. 

