### PR TITLE
Conio v0.6

### DIFF
--- a/cc65/include/conio.h
+++ b/cc65/include/conio.h
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  
     Version   0.5
-    Date      2020-06-28
+    Date      2020-07-13
 
     CHANGELOG
 

--- a/cc65/include/conio.h
+++ b/cc65/include/conio.h
@@ -15,15 +15,15 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  
-    Version   0.3
+    Version   0.4
     Date      2020-06-28
 */
 
 #ifndef M65LIBC_CONIO_H
 #define M65LIBC_CONIO_H
+#include "../include/memory.h"
 
 #define VIC_BASE            0xD000UL
-#define SCREEN_ADDRESS      0x8000
 #define REG_H640            (PEEK(VIC_BASE+0x31) & 128)
 #define REG_V400            (PEEK(VIC_BASE+0x31) & 8)
 #define REG_16BITCHARSET    (PEEK(VIC_BASE + 0x54) & 1)
@@ -33,30 +33,97 @@
 #define SCREEN_RAM_BASE_B3  (PEEK(VIC_BASE + 0x63) & 7) // upper nybble
 #define SCREEN_RAM_BASE     ( ((long)SCREEN_RAM_BASE_B3 << 24) | ((long)SCREEN_RAM_BASE_B2 << 16) | ((long)SCREEN_RAM_BASE_B1 << 8) | (SCREEN_RAM_BASE_B0) )  
 #define COLOR_RAM_BASE      0x1F800UL
-#define ATTRIB_REVERSE 0x20
-#define ATTRIB_BLINK 0x10
-#define ATTRIB_UNDERLINE 0x80
-#define ATTRIB_HIGHLIGHT 0x40
-#define COLOUR_BLACK 0
-#define COLOUR_WHITE 1
-#define COLOUR_RED 2
-#define COLOUR_CYAN 3
-#define COLOUR_PURPLE 4
-#define COLOUR_GREEN 5
-#define COLOUR_BLUE 6
-#define COLOUR_YELLOW 7
-#define COLOUR_ORANGE 8
-#define COLOUR_BROWN 9
-#define COLOUR_PINK 10
-#define COLOUR_GREY1 11
-#define COLOUR_DARKGREY 11
-#define COLOUR_GREY2 12
-#define COLOUR_GREY 12
-#define COLOUR_MEDIUMGREY 12
-#define COLOUR_LIGHTGREEN 13
-#define COLOUR_LIGHTBLUE 14
-#define COLOUR_GREY3 15
-#define COLOUR_LIGHTGREY 15
+
+#define ATTRIB_BLINK      0x10
+#define ATTRIB_REVERSE    0x20
+#define ATTRIB_UNDERLINE  0x80
+#define ATTRIB_HIGHLIGHT  0x40
+
+#define COLOUR_BLACK        0
+#define COLOUR_WHITE        1
+#define COLOUR_RED          2
+#define COLOUR_CYAN         3
+#define COLOUR_PURPLE       4
+#define COLOUR_GREEN        5
+#define COLOUR_BLUE         6
+#define COLOUR_YELLOW       7
+#define COLOUR_ORANGE       8
+#define COLOUR_BROWN        9
+#define COLOUR_PINK         10
+#define COLOUR_GREY1        11
+#define COLOUR_DARKGREY     11
+#define COLOUR_GREY2        12
+#define COLOUR_GREY         12
+#define COLOUR_MEDIUMGREY   12
+#define COLOUR_LIGHTGREEN   13
+#define COLOUR_LIGHTBLUE    14
+#define COLOUR_GREY3        15
+#define COLOUR_LIGHTGREY    15
+
+/*------------------------------------------------------------------------
+  Keyboard ASCII codes 
+  -----------------------------------------------------------------------*/
+#define ASC_A
+#define ASC_B
+#define ASC_C
+#define ASC_D
+#define ASC_E
+#define ASC_F
+#define ASC_G
+#define ASC_H
+#define ASC_I
+#define ASC_J
+#define ASC_K
+#define ASC_L
+#define ASC_M
+#define ASC_N
+#define ASC_O
+#define ASC_P
+#define ASC_Q
+#define ASC_R
+#define ASC_S
+#define ASC_T
+#define ASC_U
+#define ASC_V
+#define ASC_W
+#define ASC_X
+#define ASC_Y
+#define ASC_Z
+#define ASC_F1
+#define ASC_F3
+#define ASC_F5
+#define ASC_F7
+#define ASC_F9
+#define ASC_F11
+#define ASC_F13
+#define ASC_CRSR_RIGHT
+#define ASC_CRSR_LEFT
+#define ASC_CRSR_UP
+#define ASC_CRSR_DOWN
+/*------------------------------------------------------------------------
+  Keyboard modifiers
+  -----------------------------------------------------------------------*/
+
+#define KEYMOD_RSHIFT   1
+#define KEYMOD_LSHIFT   2
+#define KEYMOD_CTRL     4
+#define KEYMOD_MEGA     8
+#define KEYMOD_ALT      16
+#define KEYMOD_NOSCRL   32
+#define KEYMOD_CAPSLOCK 64
+
+/*------------------------------------------------------------------------
+  Screen configuration and setup
+  -----------------------------------------------------------------------*/
+
+/* Initialize library internal state */
+void conioinit(void);
+
+/* Sets the active screen RAM address */
+void setscreenaddr(long addr);
+
+/* Gets the currently active screen RAM address */
+long getscreenaddr(void);
 
  /* Clear the text screen. Color RAM will be cleared with current text color */
 void clrscr(void); 
@@ -64,6 +131,10 @@ void clrscr(void);
  /* Returns the dimensions of the text mode screen.  
     Ignores any virtual chargen dimensions */
 void fastcall screensize(unsigned char* width, unsigned char* height);
+
+/*------------------------------------------------------------------------
+  Color and Attributes
+  -----------------------------------------------------------------------*/
 
 /* Set the current border color */
 void fastcall bordercolor(unsigned char c);
@@ -86,6 +157,17 @@ void fastcall blink(unsigned char enable);
 /* Enable the highlight attribute */
 void fastcall underline(unsigned char enable);
 
+/* Set color of character cell */
+void cellcolor(unsigned char x, unsigned char y, unsigned char c);
+
+
+/*------------------------------------------------------------------------
+  Cursor Movement
+  -----------------------------------------------------------------------*/
+
+/* Put cursor at home (0,0) */
+void fastcall gohome(void);
+
 /* Put cursor at X,Y. 
    The function does not check for screen bounds! */
 void fastcall gotoxy(unsigned char x, unsigned char y);
@@ -96,14 +178,27 @@ void fastcall gotox(unsigned char x);
 /* Put cursor at row Y. The function does not check for screen bounds */
 void fastcall gotoy(unsigned char x);
 
+/* Move cursor up X times with wraparound */
+void fastcall moveup(unsigned char count);
+
+/* Move cursor down X times with wraparound */
+void fastcall movedown(unsigned char count);
+
+/* Move cursor left X times, going to next line.*/ 
+void fastcall moveleft(unsigned char count);
+
+/* Move cursor right X times, going to prev line*/
+void fastcall moveright(unsigned char count);
+
 /* Enable cursor */
 void fastcall cursor(unsigned char enable);
 
+/*------------------------------------------------------------------------
+  Text output
+  -----------------------------------------------------------------------*/
+
 /* Output a single character at current position */
 void fastcall cputc(unsigned char c);
-
-/* Set color of character cell */
-void ccellcolor(unsigned char x, unsigned char y, unsigned char c);
 
 /* Output an hex-formatted number at current position with prec digits */
 void cputhex(long n, unsigned char prec);
@@ -120,13 +215,62 @@ void cputsxy (unsigned char x, unsigned char y, const char* s);
 /* Output a character at x,y */
 void cputcxy (unsigned char x, unsigned char y, char c);
 
+/*  Print formatted output. 
+    
+    Escape strings can be used to modify attributes, move cursor,etc,
+    similar to PRINT in CBM BASIC. Available escape codes:
+   
+    Cursor positioning 
+
+    \t           Go to next tab position (multiple of 8s)
+    \r           Return
+    \n           New-line (assume \r like in C printf)
+
+    \{clr}       Clear screen       \{home}      Move cursor to home (top-left)
+    \{down}      Move cursor down   \{up}        Move cursor up
+    \{right}     Move cursor right  \{left}      Move cursor left
+
+    Attributes
+
+    \{rvson}     Reverse attribute ON   \{rvsoff}    Reverse attribute OFF
+    \{blinkon}   Reverse attribute ON   \{blinkoff}  Reverse attribute OFF
+    \{hiliteon}  Reverse attribute ON   \{hiliteoff} Reverse attribute OFF
+    \{underon}   Reverse attribute ON   \{underoff}  Reverse attribute OFF
+
+    Colors (default palette 0-15)
+
+    \{black}    \{white}    \{red}      \{cyan}     \{purple}   
+    \{green}    \{blue}     \{yellow}   \{orange}   \{brown}    
+    \{pink}     \{grey1}    \{grey2}    \{grey2}    \{ltgreen} 
+    \{ltblue}   \{grey3}
+*/
+
+unsigned char cprintf (const unsigned char* format, ...);
+
+/*------------------------------------------------------------------------
+  Keyboard input 
+  -----------------------------------------------------------------------*/
 /* Wait until a character is in the keyboard buffer and return it */
 unsigned char fastcall cgetc (void);
 
 /* Return the character in the keyboard buffer, if any */
 unsigned char fastcall kbhit (void);
 
-unsigned char cprintf (const char* format, ...);
+/* Return the key modifiers state, where bits:
+
+    Bit           Meaning
+    -----------------------------------------
+    0             Right SHIFT state
+    1             Left  SHIFT state
+    2             CTRL state
+    3             MEGA/C= state
+    4             ALT state
+    5             NOSCRL state
+    6             CAPSLOCK state
+    7             Reserved
+*/
+unsigned char fastcall getkeymodstate(void);
+
 void cscanf(const char* format, ...);
 
 

--- a/cc65/include/conio.h
+++ b/cc65/include/conio.h
@@ -15,8 +15,8 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  
-    Version   0.5
-    Date      2020-07-13
+    Version   0.6
+    Date      2020-07-14
 
     CHANGELOG
 
@@ -30,6 +30,8 @@
 
     v0.5        Added fillrect, box, cgets, wherex, wherey, togglecase functions.
                 Fixed moveXXXX to do multiple steps.  Minor optimizations in cputs/cputc.
+
+    v0.6        Added vline, hline  to draw lines.
 
 */
 
@@ -146,6 +148,24 @@
 #define BOX_STYLE_ROUND 3
 
 /*------------------------------------------------------------------------
+  Line styles
+  -----------------------------------------------------------------------*/
+#define HLINE_STYLE_TOP_THIN     0x63
+#define HLINE_STYLE_BTM_THIN     0x64
+#define HLINE_STYLE_TOP_NORMAL   0x77
+#define HLINE_STYLE_BTM_NORMAL   0x6F
+#define HLINE_STYLE_TOP1_8       0x45  // 1/8 
+#define HLINE_STYLE_TOP3_8       0x44  // 3/8 
+#define HLINE_STYLE_BTM1_8       0x52  // 1/8 
+#define HLINE_STYLE_BTM3_8       0x46  // 3/8 
+#define HLINE_STYLE_MID          0x40
+#define HLINE_STYLE_CHECKER      0x68
+#define VLINE_STYLE_LEFT_NORMAL  0x74
+#define VLINE_STYLE_RIGHT_NORMAL 0x6A
+#define VLINE_STYLE_MID          0x42
+#define VLINE_STYLE_CHECKER      0x5C
+
+/*------------------------------------------------------------------------
   Public structs
   -----------------------------------------------------------------------*/
 typedef struct tagRECT
@@ -227,7 +247,13 @@ void fillrect(const RECT *rc, unsigned char ch, unsigned char col);
 void box(const RECT *rc, unsigned char color, unsigned char style, 
          unsigned char clear, unsigned char shadow);
 
+/* Draws an horizontal line. See HLINE_ constants for style parameter  */
+void hline(unsigned char x, unsigned char y, unsigned char len, 
+           unsigned char style);
 
+/* Draws a vertical line. See VLINE_ constants for style parameter  */
+void vline(unsigned char x, unsigned char y, unsigned char len, 
+           unsigned char style);
 
 /*------------------------------------------------------------------------
   Cursor Movement
@@ -274,6 +300,9 @@ unsigned char wherey(void);
 /* Output a single character at current position */
 void fastcall cputc(unsigned char c);
 
+/* Output N copies of character at current position */
+void fastcall cputnc(unsigned char count, unsigned char c);
+
 /* Output an hex-formatted number at current position with prec digits */
 void cputhex(long n, unsigned char prec);
 
@@ -287,7 +316,11 @@ void fastcall cputs(const char* s);
 void cputsxy (unsigned char x, unsigned char y, const char* s);
 
 /* Output a character at x,y */
-void cputcxy (unsigned char x, unsigned char y, char c);
+void cputcxy (unsigned char x, unsigned char y, unsigned char c);
+
+/* Outputs N copies of a character at x,y */
+void cputncxy (unsigned char x, unsigned char y, unsigned char count, unsigned char c);
+
 
 /*  Print formatted output. 
     

--- a/cc65/src/conio.c
+++ b/cc65/src/conio.c
@@ -304,6 +304,11 @@ void cputc(unsigned char c)
     cputcxy(g_curX, g_curY, c);
 }
 
+void cputnc(unsigned char len, unsigned char c)
+{
+    cputncxy(g_curX, g_curY, len, c);
+}
+
 
 void  moveup(unsigned char count)
 {
@@ -446,6 +451,15 @@ void cputcxy (unsigned char x, unsigned char y, char c)
     g_curY = (x == g_curScreenW - 1) ? (y + 1) : y;
 }
 
+void cputncxy (unsigned char x, unsigned char y, unsigned char count, unsigned char c)
+{
+    const unsigned int offset = (y * (unsigned int) g_curScreenW) + x;
+    lfill(SCREEN_RAM_BASE + offset, c, count);
+    lfill(COLOR_RAM_BASE + offset, c, g_curTextColor);
+    g_curY = y + ((x + count) / g_curScreenW);
+    g_curX = (x + count) % g_curScreenW;
+}
+
 void fillrect(const RECT *rc, unsigned char ch, unsigned char col)
 {
     register unsigned char i = 0;
@@ -494,6 +508,19 @@ void box(const RECT *rc, unsigned char color, unsigned char style, unsigned char
     textcolor(prevCol);
 }
 
+void hline(unsigned char x, unsigned char y, unsigned char len, unsigned char style)
+{
+    cputncxy(x, y, len, style);
+}
+
+void vline(unsigned char x, unsigned char y, unsigned char len, unsigned char style)
+{
+    register unsigned char i;
+    for (i = 0; i < len; ++i)
+    {
+        cputcxy(x, y + i, style);
+    }
+}
 
 unsigned char cgetc (void)
 {


### PR DESCRIPTION
The new conio.h is updated with new features, as follows.

* Added functions: getscreensize, setscreensize, setextendedattributes, set16bitcharmode, moveup,moveleft,moveright, movedown, gohome,  flushkeybuf.
*  Cache screen sizes for faster calls.
* Added cprintf escape codes for formatted screen colors and attributes.
* Added proper initialization function.
* Fixed a bug where screen was fixed at $8000!
* Added fillrect, box, cgets, wherex, wherey, togglecase functions.
* Fixed moveXXXX to do multiple steps.  Minor optimizations in cputs/cputc.
* Added vline, hline  to draw lines.
The cprintf feature allows for users to enter CBM PRINT like strings to format screen, including clearing, moving cursor and setting attributes.

For example the C code:

```
cprintf("{rvson}{yel}   formatted-print    {d}{red} {d}{cyan} {d}{grn} {wht}{blon}blink{bloff}{rvsoff} {lgrn}{u}{ulon}underline{uloff}");
```

Will yield (assume blink is really blinking):

![image](https://user-images.githubusercontent.com/4740613/86558056-aa03d480-bf2e-11ea-8488-515a1fc3feba.png)


Thanks.