### PR TITLE
Add signalling function for unit testing

### DIFF
--- a/cc65/include/tests.h
+++ b/cc65/include/tests.h
@@ -1,0 +1,19 @@
+#ifndef TESTS_H
+#define TESTS_H
+
+#define TEST_START 0xf0
+#define TEST_SKIP 0xf1
+#define TEST_PASS 0xf2
+#define TEST_FAIL 0xf3
+#define TEST_ERROR 0xf4
+#define TEST_DONEALL 0xff
+
+/** \m65libsummary{unit_test_report}{Reports unit test result to the host machine}
+    \m65libsyntax    {void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status);}
+    \m65libparam     {issue}{The issue number that identifies the test issue}
+    \m65libparam     {sub}{The sub issue number (for multiple tests per issue)}
+    \m65libparam     {status}{The test status to be sent}
+*/
+void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status);
+
+#endif

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -1,0 +1,22 @@
+
+unsigned char __tests_out;
+
+void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status)
+{
+    __tests_out = issue & 0xff;
+    __asm__("LDA %v", __tests_out);
+    __asm__("STA $D643");
+    __asm__("NOP");
+    __tests_out = issue >> 8;
+    __asm__("LDA %v", __tests_out);
+    __asm__("STA $D643");
+    __asm__("NOP");
+    __tests_out = sub;
+    __asm__("LDA %v", __tests_out);
+    __asm__("STA $D643");
+    __asm__("NOP");
+    __tests_out = __tests_out;
+    __asm__("LDA %v", __tests_out);
+    __asm__("STA $D643");
+    __asm__("NOP");
+}


### PR DESCRIPTION
Adds a basic reporting mechanism for unit testing, which can be used to signal the results of a test to a host machine connected via the serial port. m65 recognizes those signals when launched with the -u option.

(original code by @gardners, slightly modified to be used from mega65-libc)
