### PR TITLE
Add setname functionality

### DIFF
--- a/cc65/include/tests.h
+++ b/cc65/include/tests.h
@@ -6,6 +6,7 @@
 #define TEST_PASS 0xf2
 #define TEST_FAIL 0xf3
 #define TEST_ERROR 0xf4
+#define TEST_SETNAME 0xfe
 #define TEST_DONEALL 0xff
 
 /** \m65libsummary{unit_test_report}{Reports unit test result to the host machine}
@@ -15,5 +16,7 @@
     \m65libparam     {status}{The test status to be sent}
 */
 void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status);
+
+
 
 #endif

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -15,7 +15,7 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    __tests_out = __status;
+    __tests_out = status;
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -24,7 +24,6 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
   __asm__("NOP");
 }
 
-
 void unit_test_set_current_name(char* name)
 {
   unsigned char* current;
@@ -34,10 +33,14 @@ void unit_test_set_current_name(char* name)
 
   while (*current) {
     __tests_out = *current;
-    fprintf(stderr,"%c\n",__tests_out);
+    fprintf(stderr, "%c\n", __tests_out);
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
     current++;
   }
+
+  __asm__("LDA #92");
+  __asm__("STA $D643");
+  __asm__("NOP");
 }

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -15,7 +15,7 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    __tests_out = __tests_out;
+    __tests_out = __status;
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -1,22 +1,43 @@
 
+#include <string.h>
+#include <stdio.h>
+
 unsigned char __tests_out;
 
 void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status)
 {
-    __tests_out = issue & 0xff;
+  __tests_out = issue & 0xff;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+  __tests_out = issue >> 8;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+  __tests_out = sub;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+  __tests_out = status;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+}
+
+
+void unit_test_set_current_name(char* name)
+{
+  unsigned char* current;
+
+  unit_test_report(0, 0, 0xfe);
+  current = name;
+
+  while (*current) {
+    __tests_out = *current;
+    fprintf(stderr,"%c\n",__tests_out);
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    __tests_out = issue >> 8;
-    __asm__("LDA %v", __tests_out);
-    __asm__("STA $D643");
-    __asm__("NOP");
-    __tests_out = sub;
-    __asm__("LDA %v", __tests_out);
-    __asm__("STA $D643");
-    __asm__("NOP");
-    __tests_out = status;
-    __asm__("LDA %v", __tests_out);
-    __asm__("STA $D643");
-    __asm__("NOP");
+    current++;
+  }
 }


### PR DESCRIPTION
Adds functionality to set the current test name.

For some unknown reason, a '0' as end-of-string marker sometimes gets corrupted when sending over the serial interface; hence we're using the pound sign for a workaround.

