### PR TITLE
Add functions for setting the current test name and logging messages to the host computer

### DIFF
--- a/cc65/include/tests.h
+++ b/cc65/include/tests.h
@@ -6,6 +6,7 @@
 #define TEST_PASS 0xf2
 #define TEST_FAIL 0xf3
 #define TEST_ERROR 0xf4
+#define TEST_SETNAME 0xfe
 #define TEST_DONEALL 0xff
 
 /** \m65libsummary{unit_test_report}{Reports unit test result to the host machine}
@@ -15,5 +16,7 @@
     \m65libparam     {status}{The test status to be sent}
 */
 void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status);
+
+
 
 #endif

--- a/cc65/include/tests.h
+++ b/cc65/include/tests.h
@@ -6,6 +6,7 @@
 #define TEST_PASS 0xf2
 #define TEST_FAIL 0xf3
 #define TEST_ERROR 0xf4
+#define TEST_LOG 0xfd
 #define TEST_SETNAME 0xfe
 #define TEST_DONEALL 0xff
 
@@ -17,6 +18,17 @@
 */
 void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status);
 
+/** \m65libsummary{unit_test_set_current_name}{Reports current test name to the host machine}
+    \m65libsyntax    {void unit_test_set_current_name(char *name);}
+    \m65libparam     {name}{The human-readable name of the current test}
+*/
+void unit_test_set_current_name(char *name);
+
+/** \m65libsummary{unit_test_log}{Logs a message on the host machibe}
+    \m65libsyntax    {void unit_test_log(char *msg);}
+    \m65libparam     {msg}{The message to be logged}
+*/
+void unit_test_log(char *msg);
 
 
 #endif

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -15,7 +15,7 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    __tests_out = __status;
+    __tests_out = status;
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -24,21 +24,32 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
   __asm__("NOP");
 }
 
-void unit_test_set_current_name(char* name)
+void _unit_test_msg(char *msg, char cmd)
 {
-  unsigned char* current;
+  unsigned char *current;
 
-  unit_test_report(0, 0, 0xfe);
-  current = name;
+  unit_test_report(0, 0, cmd);
+  current = msg;
 
-  while (*current) {
-    __tests_out = *current;
+  while (*current)
+  {
+    __tests_out = *current++;
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    current++;
   }
+
   __asm__("LDA #92");
   __asm__("STA $D643");
   __asm__("NOP");
+}
+
+void unit_test_set_current_name(char *name)
+{
+  _unit_test_msg(name, 0xfe);
+}
+
+void unit_test_log(char *msg)
+{
+  _unit_test_msg(msg, 0xfd);
 }

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -24,7 +24,6 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
   __asm__("NOP");
 }
 
-
 void unit_test_set_current_name(char* name)
 {
   unsigned char* current;
@@ -34,10 +33,14 @@ void unit_test_set_current_name(char* name)
 
   while (*current) {
     __tests_out = *current;
-    fprintf(stderr,"%c\n",__tests_out);
+    fprintf(stderr, "%c\n", __tests_out);
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
     current++;
   }
+
+  __asm__("LDA #92");
+  __asm__("STA $D643");
+  __asm__("NOP");
 }

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -15,7 +15,7 @@ void unit_test_report(unsigned short issue, unsigned char sub, unsigned char sta
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    __tests_out = __tests_out;
+    __tests_out = __status;
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");

--- a/cc65/src/tests.c
+++ b/cc65/src/tests.c
@@ -1,22 +1,43 @@
 
+#include <string.h>
+#include <stdio.h>
+
 unsigned char __tests_out;
 
 void unit_test_report(unsigned short issue, unsigned char sub, unsigned char status)
 {
-    __tests_out = issue & 0xff;
+  __tests_out = issue & 0xff;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+  __tests_out = issue >> 8;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+  __tests_out = sub;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+  __tests_out = status;
+  __asm__("LDA %v", __tests_out);
+  __asm__("STA $D643");
+  __asm__("NOP");
+}
+
+
+void unit_test_set_current_name(char* name)
+{
+  unsigned char* current;
+
+  unit_test_report(0, 0, 0xfe);
+  current = name;
+
+  while (*current) {
+    __tests_out = *current;
+    fprintf(stderr,"%c\n",__tests_out);
     __asm__("LDA %v", __tests_out);
     __asm__("STA $D643");
     __asm__("NOP");
-    __tests_out = issue >> 8;
-    __asm__("LDA %v", __tests_out);
-    __asm__("STA $D643");
-    __asm__("NOP");
-    __tests_out = sub;
-    __asm__("LDA %v", __tests_out);
-    __asm__("STA $D643");
-    __asm__("NOP");
-    __tests_out = status;
-    __asm__("LDA %v", __tests_out);
-    __asm__("STA $D643");
-    __asm__("NOP");
+    current++;
+  }
 }


### PR DESCRIPTION
Two extensions to the existing functionality:

- When unit testing from a connected host computer, tests can now have a human-readable identifier (the 'test name'), which can be set via unit_test_set_current_name(aString)
- also, it is possible to log messages to the host computer using unit_test_log(aString).

(for this to work, an updated version m65-tools is required, see https://github.com/MEGA65/mega65-tools/pull/59)