### PR TITLE
Adds FCIO routines and extends memory.h

### DIFF
--- a/cc65/include/fcio.h
+++ b/cc65/include/fcio.h
@@ -1,0 +1,486 @@
+
+/*! @file fcio.h
+    @brief Full colour mode i/o library for the MEGA65
+    
+    Details.
+*/
+
+#ifndef __FCIO
+#define __FCIO
+
+#include <memory.h>
+#include <stdbool.h>
+
+
+#define FCBUFSIZE 0xff
+
+#ifndef byte
+typedef unsigned char byte;
+#endif
+
+#ifndef himemPtr
+typedef unsigned long himemPtr;
+#endif
+
+#ifndef word
+typedef unsigned int word;
+#endif
+
+typedef struct _fcioConf {
+    himemPtr screenBase;
+    himemPtr reservedBitmapBase;
+    himemPtr reservedPaletteBase;
+    himemPtr dynamicPaletteBase;
+    himemPtr dynamicBitmapBase;
+    himemPtr colourBase;
+} fcioConf;
+
+extern char *fcbuf;
+
+// --------------- graphics ------------------
+
+typedef struct _fciInfo
+{
+    himemPtr baseAdr;        ///< bitmap base address
+    himemPtr paletteAdr;     ///< palette data base address
+    byte paletteSize;        ///< size of palette (in palette entries)
+    bool reservedSysPalette; ///< if true, don't use colours 0-15
+    byte columns;            ///< number of character columns for image
+    byte rows;               ///< number of character rows
+    word size;               ///< size of bitmap
+} fciInfo;
+
+typedef struct _textwin
+{
+    byte xc;            ///< current cursor X position
+    byte yc;            ///< current cursor Y position
+    byte x0;            ///< X origin
+    byte y0;            ///< Y origin
+    byte width;         ///< window width
+    byte height;        ///< window height
+    byte textcolor;     ///< current window text colour
+    byte extAttributes; ///< current window extended text attributes
+} textwin;
+
+extern byte gScreenColumns;  ///< number of screen columns (in characters)
+extern byte gScreenRows;     ///< number of screen rows (in characters)
+extern textwin *gCurrentWin; ///< current window
+
+// --- general & initializations ---
+
+/**
+ * @brief initialize fcio library with given initial screen mode
+ * 
+ * @param h640 horizontal resolution; true: 640px, false: 320px
+ * @param v400 vertical resolution; true: 400px, false: 200px
+ * @param config pointer to FCIO config block (or NULL for standard configuration) 
+ * @param rows character rows (or 0 for default row count)
+ * @param reservedBitmapFile reserved bitmap to load upon initialization (or NULL for none)
+ */
+void fc_init(byte h640, byte v400, fcioConf *config, byte rows, char *reservedBitmapFile);
+
+/**
+ * @brief set new full colour screen mode
+ * 
+ * @param h640 horizontal resolution; true: 640px, false: 320px
+ * @param v400 vertical resolution; true: 400px, false: 200px
+ * @param rows character rows (or 0 for standard configuration)
+ */
+void fc_screenmode(byte h640, byte v400, byte rows);
+
+/**
+ * @brief fall back to 8 bit screen mode
+ * 
+ */
+void fc_go8bit();
+
+/**
+ * @brief display fatal error message and stop execution
+ * 
+ * @param format printf-style format string
+ * @param ... format string parameters
+ */
+void fc_fatal(const char *format, ...);
+
+// ----------------------------------------------------------------------------
+// lines and blocks
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief draw a block in the current window
+ * 
+ * @param x0 origin x
+ * @param y0 origin y
+ * @param width block width
+ * @param height block height
+ * @param character ascii character to plot
+ * @param col colour to plot
+ */
+void fc_block(byte x0, byte y0, byte width, byte height, byte character, byte col);
+
+/**
+ * @brief draw a horizontal line using extended (==fcm bitmap) characters
+ * 
+ * @param x origin x
+ * @param y origin y
+ * @param width width
+ * @param lineChar bitmap character index to use
+ */
+void fc_hlinexy(byte x, byte y, byte width, byte lineChar);
+
+/**
+ * @brief draw a vertical line using extended (==fcm bitmap) characters
+ * 
+ * @param x origin x
+ * @param y origin y
+ * @param height height
+ * @param lineChar bitmap character index to use
+ */
+void fc_vlinexy(byte x, byte y, byte height, byte lineChar);
+void fc_line(byte x, byte y, byte width, byte character, byte col);
+
+// ----------------------------------------------------------------------------
+// --- keyboard input ---
+// ----------------------------------------------------------------------------
+
+void fc_emptyBuffer(void);
+unsigned char fc_cgetc(void);
+char fc_getkey(void);
+char fc_getkeyP(byte x, byte y, const char *prompt);
+
+/**
+ * @brief get user input
+ * 
+ * @param maxlen maximum length
+ * @return char* a newly allocated area in memory containing the input string
+ */
+char *fc_input(byte maxlen);
+int fc_getnum(byte maxlen);
+
+// ----------------------------------------------------------------------------
+// --- string and character output ---
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief clears the current text window
+ * 
+ */
+void fc_clrscr();
+
+/**
+ * @brief put character at current cursor position
+ * 
+ * @param c the character
+ */
+void fc_putc(char c);
+
+/**
+ * @brief put string at current cursor position
+ * 
+ * @param s the string
+ */
+void fc_puts(const char *s);
+
+/**
+ * @brief put string at given position in current window
+ * 
+ * @param x 
+ * @param y 
+ * @param s the string
+ */
+void fc_putsxy(byte x, byte y, char *s);
+
+/**
+ * @brief put character at given position in current window
+ * 
+ * @param x 
+ * @param y 
+ * @param c the character
+ */
+void fc_putcxy(byte x, byte y, char c);
+
+/**
+ * @brief print string at current cursor position
+ * 
+ * @param format format string
+ * @param ... format parameters
+ */
+void fc_printf(const char *format, ...);
+
+/**
+ * @brief set cursor position in current window
+ * 
+ * @param x 
+ * @param y 
+ */
+void fc_gotoxy(byte x, byte y);
+
+/**
+ * @brief get cursor x position
+ * 
+ * @return byte cursor y position
+ */
+byte fc_wherex();
+
+/**
+ * @brief get cursor y position
+ * 
+ * @return byte cursor y position
+ */
+byte fc_wherey();
+
+/**
+ * @brief set active window
+ * 
+ * @param aWin window to activate
+ */
+void fc_setwin(textwin *aWin);
+
+/**
+ * @brief convenience method to create a window structure
+ * 
+ * @param x0 x origin
+ * @param y0 y origin
+ * @param width window width
+ * @param height window height
+ * @return textwin* the created window structure
+ */
+textwin *fc_makeWin(byte x0, byte y0, byte width, byte height);
+
+/**
+ * @brief reset text window to whole screen
+ * 
+ */
+void fc_resetwin();
+
+/**
+ * @brief cursor control
+ * 
+ * @param onoff 1=on, 0=off
+ */
+void fc_cursor(byte onoff);
+
+/**
+ * @brief center string at given position
+ * 
+ * @param x x origin
+ * @param y y origin
+ * @param width width of area
+ * @param text text to center
+ */
+void fc_center(byte x, byte y, byte width, char *text);
+
+/**
+ * @brief scrolls the content of the current window up
+ * 
+ */
+void fc_scrollUp();
+
+/**
+ * @brief scrolls the contents of the current window down
+ * 
+ */
+void fc_scrollDown();
+
+// ----------------------------------------------------------------------------
+// colour, attributes and palette handling
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief set or reset the revers attribute
+ * 
+ * @param f reverse attribute flag
+ */
+void fc_revers(byte f);
+
+/**
+ * @brief set or reset the flash attribute
+ * 
+ * @param f flash attribute flag
+ */
+void fc_flash(byte f);
+
+/**
+ * @brief set or reset the bold attribute
+ * 
+ * @param f bold attribute flag
+ */
+void fc_bold(byte f);
+
+/**
+ * @brief set or reset the underline attribute
+ * 
+ * @param f underline attribute flag
+ */
+void fc_underline(byte f);
+
+/**
+ * @brief load palette data into the VIC
+ * 
+ * @param adr address palette data (de-nybellized triplets)
+ * @param size size (in palette entries)
+ * @param reservedSysPalette whether to overwrite colours 0-15
+ */
+void fc_loadPalette(himemPtr adr, byte size, byte reservedSysPalette);
+
+/**
+ * @brief set palette entry
+ * 
+ * @param num palette index (0-255)
+ * @param red red (0-255)
+ * @param green green (0-255)
+ * @param blue blue (0-255)
+ */
+void fc_setPalette(byte num, byte red, byte green, byte blue);
+
+/**
+ * @brief load FCI palette into the VIC
+ * 
+ * @param info pointer to FCI image info block
+ */
+void fc_loadFCIPalette(fciInfo *info);
+
+/**
+ * @brief set palette entries to black
+ * 
+ * @param reservedSysPalette exclude colours 0-15
+ */
+void fc_zeroPalette(byte reservedSysPalette);
+
+/**
+ * @brief fade palette to or from the desired values
+ * 
+ * @param adr address of palette data
+ * @param size number of palette entries
+ * @param reservedSysPalette exclude colours 0-15
+ * @param steps number of steps for fade (max. 255)
+ * @param fadeOut if true, fade out rather than in
+ */
+void fc_fadePalette(himemPtr adr, byte size, byte reservedSysPalette, byte steps, bool fadeOut);
+
+/**
+ * @brief reset palette to reserved FCI palette
+ * 
+ * If a reserved FCI is used (see @a fc_loadReservedFCI), reset the current
+ * palette to the reserved one.
+ */
+void fc_resetPalette();
+
+/**
+ * @brief set text colour of current window
+ * 
+ * @param c text colour index
+ */
+void fc_textcolor(byte c);
+
+/**
+ * @brief set border colour
+ * 
+ */
+#define fc_bordercolor(C) POKE(0xd020u, C)
+
+/**
+ * @brief set background colour
+ * 
+ */
+#define fc_bgcolor(C) POKE(0xd021u, C)
+
+// ----------------------------------------------------------------------------
+// graphic areas
+// ----------------------------------------------------------------------------
+
+/**
+ * @brief free automatically allocated graphic areas
+ * 
+ */
+void fc_freeGraphAreas(void);
+
+/**
+ * @brief Adds a graphics rectangle to the screen.
+ * 
+ * @param x0 x origin (in characters)
+ * @param y0 y origin (in characters)
+ * @param width width (in characters)
+ * @param height height (in characters)
+ * @param bitmapData address of bitmap data
+ * 
+ * Display a bitmap that has been loaded with @a fc_loadFCI without
+ * setting the palette (useful for fading in images after loading)
+ * 
+ */
+void fc_addGraphicsRect(byte x0, byte y0, byte width, byte height,
+                        himemPtr bitmapData);
+
+/**
+ * @brief allocate memory for FCI file and load it
+ *
+ * @param filename name of FCI file to load
+ * @param address address to load bitmap (or 0 for automatic allocation)
+ * @param pAddress address to load palette (or 0 for automatic allocation)
+ * @return fciInfo* info block containging start address and metadata
+ * 
+ * This function is used to load an FCI image into memory. If used with automatic
+ * memory allocation (0 for @a address and @a pAddress), memory is taken from banks 4 
+ * and 5 to store the bitmap data.
+ * 
+ * When automatically alloacting graphic areas, it is quite possible to run 
+ * out of memory. Therefore, it is advisable to always clear previously allocated
+ * graphic areas with @a fc_freeGraphicAreas after usage.
+ * 
+ * @warning only loads the picture, doesn't display it!
+ * 
+ */
+fciInfo *fc_loadFCI(char *filename, himemPtr address, himemPtr paletteAddress);
+
+/**
+ * @brief display FCI image
+ * 
+ * @param info FCI image info block
+ * @param x0 x origin (in characters)
+ * @param y0 y origin (in characters)
+ * @param setPalette also overwrites current palette with image palette if true
+ */
+void fc_displayFCI(fciInfo *info, byte x0, byte y0, bool setPalette);
+
+/**
+ * @brief fade in FCI image
+ * 
+ * @param info FCI image info block
+ * @param x0 x origin (in characters)
+ * @param y0 y origin (in characters)
+ * @param steps number of steps for fade (255=max)
+ */
+void fc_fadeFCI(fciInfo *info, byte x0, byte y0, byte steps);
+
+/**
+ * @brief load FCI file and display it
+ *
+ * @param filename FCI file to load
+ * @param x0 origin x
+ * @param y0 origin y
+ * @return fciInfo* associated fciInfo block for file
+ */
+fciInfo *fc_displayFCIFile(char *filename, byte x0, byte y0);
+
+/**
+ * @brief plot extended (==full colour) character
+ * 
+ * @param x screen column
+ * @param y screen row
+ * @param c character index
+ */
+void fc_plotExtChar(byte x, byte y, byte c);
+
+/**
+ * @brief plot petscii character
+ * 
+ * @param x screen column
+ * @param y screen row
+ * @param c character code
+ * @param color character colour
+ * @param exAttr extended attributes
+ */
+void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr);
+
+
+#endif

--- a/cc65/include/memory.h
+++ b/cc65/include/memory.h
@@ -1,13 +1,16 @@
 #ifndef __MEGA65_MEMORY_H
 #define __MEGA65_MEMORY_H
 
-struct dmagic_dmalist {
+struct dmagic_dmalist
+{
   // Enhanced DMA options
   unsigned char option_0b;
   unsigned char option_80;
   unsigned char source_mb;
   unsigned char option_81;
   unsigned char dest_mb;
+  unsigned char option_85;
+  unsigned char dest_skip;
   unsigned char end_of_options;
 
   // F018B format DMA request
@@ -17,7 +20,7 @@ struct dmagic_dmalist {
   unsigned char source_bank;
   unsigned int dest_addr;
   unsigned char dest_bank;
-  unsigned char sub_cmd;  // F018B subcmd
+  unsigned char sub_cmd; // F018B subcmd
   unsigned int modulo;
 };
 
@@ -29,14 +32,16 @@ unsigned char lpeek(long address);
 unsigned char lpeek_debounced(long address);
 void lpoke(long address, unsigned char value);
 void lcopy(long source_address, long destination_address,
-	   unsigned int count);
+           unsigned int count);
 void lfill(long destination_address, unsigned char value,
-	   unsigned int count);
+           unsigned int count);
+void lfill_skip(long destination_address, unsigned char value,
+                unsigned int count, unsigned char skip);
 #ifdef __CC65__
-#define POKE(X,Y) (*(unsigned char*)(X))=Y
-#define PEEK(X) (*(unsigned char*)(X))
+#define POKE(X, Y) (*(unsigned char *)(X)) = Y
+#define PEEK(X) (*(unsigned char *)(X))
 #else
-#define POKE(X,Y)
+#define POKE(X, Y)
 #define PEEK(X)
 #endif
 

--- a/cc65/src/fcio.c
+++ b/cc65/src/fcio.c
@@ -1,0 +1,1042 @@
+/*
+ * fcio.c
+ * MEGA65 full colour mode console and bitmap display support
+ *
+ * Copyright (C) 2019-21 - Stephan Kleinert
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#define __fastcall__ // to silence stupid vscode warning
+
+
+#include <fcio.h>
+#include <memory.h>
+#include <c64.h>
+#include <cbm.h>
+#include <conio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdbool.h>
+
+#define MAX_FCI_BLOCKS 16
+#define MAX_WINDOWS 8
+
+#define TOPBORDER_PAL 0x58
+#define BOTTOMBORDER_PAL 0x1e8
+
+#define TOPBORDER_NTSC 0x27
+#define BOTTOMBORDER_NTSC 0x1b7
+
+char *fcbuf = (char *)0x0400; // general purpose buffer
+// DMAlist is at 0x500
+fciInfo **infoBlocks = (fciInfo **)0x0600; // pointers to fci info blocks
+textwin *defaultWin = (textwin *)0x0700;
+textwin *gCurrentWin;
+fcioConf *gFcioConfig;
+byte winCount = MAX_WINDOWS;
+
+fcioConf stdConfig = {
+    0x12000l,   // location of 16 bit screen
+    0x14000l,   // reserved bitmap graphics graphics
+    0x15000l,   // reserved system palette
+    0x15300l,   // loaded palettes base
+    0x40000l,   // loaded bitmaps base
+    0xff81000l, // attribute/colour ram
+};
+
+#define VIC_BASE 0xD000UL
+
+#define VIC2CTRL (*(unsigned char *)(0xd016))
+#define VIC4CTRL (*(unsigned char *)(0xd054))
+#define VIC3CTRL (*(unsigned char *)(0xd031))
+#define LINESTEP_LO (*(unsigned char *)(0xd058))
+#define LINESTEP_HI (*(unsigned char *)(0xd059))
+#define CHRCOUNT (*(unsigned char *)(0xd05e))
+#define HOTREG (*(unsigned char *)(0xd05d))
+
+#define SCNPTR_0 (*(unsigned char *)(0xd060))
+#define SCNPTR_1 (*(unsigned char *)(0xd061))
+#define SCNPTR_2 (*(unsigned char *)(0xd062))
+#define SCNPTR_3 (*(unsigned char *)(0xd063))
+
+// special graphics characters
+#define H_COLUMN_END 4
+#define H_COLUMN_START 5
+#define CURSOR_CHARACTER 0x5f
+
+#define bitset(byte, nbit) ((byte) |= (1 << (nbit)))
+#define bitclear(byte, nbit) ((byte) &= ~(1 << (nbit)))
+#define bitflip(byte, nbit) ((byte) ^= (1 << (nbit)))
+#define bitcheck(byte, nbit) ((byte) & (1 << (nbit)))
+
+#define COLOUR_RAM_OFFSET gFcioConfig->colourBase - 0xff80000l
+
+word gScreenSize;          // screen size (in characters)
+byte gScreenColumns;       // number of screen columns (in characters)
+byte gScreenRows;          // number of screen rows (in characters)
+himemPtr nextFreeGraphMem; // location of next free graphics block in banks 4 & 5
+himemPtr nextFreePalMem;   // location of next free palette memory block
+byte infoBlockCount;       // number of info blocks
+byte cgi;                  // universal loop var
+
+int gTopBorder;
+int gBottomBorder;
+
+// flags
+bool csrflag; // cursor on/off
+bool autoCR;
+
+unsigned int readExt(FILE *inFile, himemPtr addr, byte skipCBMAddressBytes) {
+
+    unsigned int readBytes;
+    unsigned int overallRead;
+    unsigned long insertPos;
+
+    insertPos= addr;
+    overallRead= 0;
+
+    if (skipCBMAddressBytes) {
+        fread(fcbuf, 1, 2, inFile);
+    }
+
+    do {
+        readBytes= fread(fcbuf, 1, FCBUFSIZE, inFile);
+        if (readBytes) {
+            overallRead+= readBytes;
+            lcopy((long)fcbuf, insertPos, readBytes);
+            insertPos+= readBytes;
+        }
+    } while (readBytes);
+
+    return overallRead;
+}
+
+unsigned int loadExt(char *filename, himemPtr addr, byte skipCBMAddressBytes) {
+
+    FILE *inFile;
+    word readBytes;
+
+    inFile= fopen(filename, "r");
+    readBytes= readExt(inFile, addr, skipCBMAddressBytes);
+    fclose(inFile);
+
+    if (readBytes==0) {
+        fc_fatal("0 bytes from %s",filename);
+    }
+
+    return readBytes;
+}
+
+void fc_loadReservedBitmap(char *name)
+{
+    fc_loadFCI(name, gFcioConfig->reservedBitmapBase, gFcioConfig->reservedPaletteBase);
+    fc_resetPalette();
+}
+
+void fc_init(byte h640, byte v400, fcioConf *config, byte rows, char *reservedBitmapFile)
+{
+    mega65_io_enable();
+
+    gFcioConfig = config ? config : &stdConfig;
+
+    if ((PEEK(53359U) & 128) == 0)
+    {
+        gTopBorder = TOPBORDER_PAL;
+        gBottomBorder = BOTTOMBORDER_PAL;
+    }
+    else
+    {
+        gTopBorder = TOPBORDER_NTSC;
+        gBottomBorder = BOTTOMBORDER_NTSC;
+    }
+    infoBlockCount = 0;
+    for (cgi = 0; cgi < MAX_FCI_BLOCKS; ++cgi)
+    {
+        infoBlocks[cgi] = NULL;
+    }
+    fc_freeGraphAreas();
+    bgcolor(COLOR_BLACK);
+    bordercolor(COLOR_BLACK);
+
+    fc_screenmode(h640, v400, rows);
+    autoCR = false;
+
+    if (reservedBitmapFile)
+    {
+        fc_loadReservedBitmap(reservedBitmapFile);
+    }
+    fc_textcolor(COLOR_GREEN);
+}
+
+static unsigned char swp;
+unsigned char nyblswap(unsigned char in) // oh why?!
+{
+    swp = in;
+    __asm__("lda %v", swp);
+    __asm__("asl  a");
+    __asm__("adc  #$80");
+    __asm__("rol a");
+    __asm__("asl a");
+    __asm__("adc  #$80");
+    __asm__("rol  a");
+    __asm__("sta %v", swp);
+    return swp;
+}
+
+void fc_flash(byte f)
+{
+    if (f)
+        bitset(gCurrentWin->extAttributes, 4);
+    else
+        bitclear(gCurrentWin->extAttributes, 4);
+}
+
+void fc_revers(byte f)
+{
+    if (f)
+        bitset(gCurrentWin->extAttributes, 5);
+    else
+        bitclear(gCurrentWin->extAttributes, 5);
+}
+
+void fc_bold(byte f)
+{
+    if (f)
+        bitset(gCurrentWin->extAttributes, 6);
+    else
+        bitclear(gCurrentWin->extAttributes, 6);
+}
+
+void fc_underline(byte f)
+{
+    if (f)
+        bitset(gCurrentWin->extAttributes, 7);
+    else
+        bitclear(gCurrentWin->extAttributes, 7);
+}
+
+void fc_resetPalette()
+{
+    mega65_io_enable();
+    fc_loadPalette(gFcioConfig->reservedPaletteBase, 255, false);
+}
+
+void fc_fatal(const char *format, ...)
+{
+    char buf[160];
+    va_list args;
+
+    mega65_io_enable();
+    va_start(args, format);
+    vsprintf(buf, format, args);
+    va_end(args);
+    fc_go8bit();
+    bordercolor(2);
+    textcolor(2);
+    bgcolor(0);
+    puts("## fatal error ##");
+    puts(buf);
+    while (1)
+        ;
+}
+
+void fc_freeGraphAreas(void)
+{
+    for (cgi = 0; cgi < infoBlockCount; ++cgi)
+    {
+        if (infoBlocks[cgi] != NULL)
+        {
+            free(infoBlocks[cgi]);
+            infoBlocks[cgi] = NULL;
+        }
+    }
+    nextFreeGraphMem = gFcioConfig->dynamicBitmapBase;
+    nextFreePalMem = gFcioConfig->dynamicPaletteBase;
+    infoBlockCount = 0;
+}
+
+/*
+very simple graphics memory allocation scheme:
+try to find space in 128K beginning at GRAPHBASE, without
+crossing bank boundaries. If everything's full, bail out.
+*/
+
+himemPtr fc_allocGraphMem(word size)
+{
+    himemPtr adr = nextFreeGraphMem;
+
+    if (nextFreeGraphMem + size < gFcioConfig->dynamicBitmapBase + 0x10000)
+    {
+        nextFreeGraphMem += size;
+        return adr;
+    }
+    if (nextFreeGraphMem < gFcioConfig->dynamicBitmapBase + 0x10000)
+    {
+        nextFreeGraphMem = gFcioConfig->dynamicBitmapBase + 0x10000;
+        adr = nextFreeGraphMem;
+    }
+    if (nextFreeGraphMem + size < gFcioConfig->dynamicBitmapBase + 0x20000)
+    {
+        nextFreeGraphMem += size;
+        return adr;
+    }
+    return 0;
+}
+
+himemPtr fc_allocPalMem(word size)
+{
+    himemPtr adr = nextFreePalMem;
+    if (nextFreePalMem < 0x1e000) // TODO: don't hardcode boundaries
+    {
+        nextFreePalMem += size;
+        return adr;
+    }
+    return 0;
+}
+
+char asciiToPetscii(byte c)
+{
+    // TODO: could be made much faster with translation table
+    if (c == '_')
+    {
+        return 100;
+    }
+    if (c >= 64 && c <= 95)
+    {
+        return c - 64;
+    }
+    if (c >= 96 && c < 192)
+    {
+        return c - 32;
+    }
+    if (c >= 192)
+    {
+        return c - 128;
+    }
+    return c;
+}
+
+void adjustBorders(byte extraRows, byte extraColumns)
+{
+    // TODO: support for extra columns
+
+    byte extraTopRows = 0;
+    byte extraBottomRows = 0;
+    int newBottomBorder;
+
+    extraBottomRows = extraRows / 2;
+    extraTopRows = extraRows - extraBottomRows;
+
+    POKE(53320u, gTopBorder - (extraTopRows * 8)); // top border position
+    POKE(53326u, gTopBorder - (extraTopRows * 8)); // top text position
+
+    newBottomBorder = gBottomBorder + (extraBottomRows * 8);
+
+    POKE(53322U, newBottomBorder % 256);
+    POKE(53323U, newBottomBorder / 256);
+
+    POKE(53371u, gScreenRows);
+}
+
+void fc_screenmode(byte h640, byte v400, byte rows)
+{
+    int extraRows = 0;
+
+    mega65_io_enable();
+    if (rows == 0)
+    {
+        gScreenRows = v400 ? 50 : 25;
+    }
+    else
+    {
+        gScreenRows = rows;
+    }
+
+    HOTREG |= 0x80;   // enable HOTREG if previously disabled
+    VIC4CTRL |= 0x04; // enable full colour for characters with high byte set
+    VIC4CTRL |= 0x01; // enable 16 bit characters
+
+    if (h640)
+    {
+        VIC3CTRL |= 0x80; // enable H640
+        VIC2CTRL |= 0x01; // shift one pixel to the right (VIC-III bug)
+        gScreenColumns = 80;
+    }
+    else
+    {
+        VIC3CTRL &= 0x7f; // disable H640
+        gScreenColumns = 40;
+    }
+
+    if (v400)
+    {
+        VIC3CTRL |= 0x08;
+        extraRows = gScreenRows - 50;
+    }
+    else
+    {
+        VIC3CTRL &= 0xf7;
+        extraRows = (gScreenRows - 25) * 2;
+    }
+
+    gScreenSize = gScreenRows * gScreenColumns;
+    lfill_skip(gFcioConfig->screenBase, 32, gScreenSize, 2);
+    lfill(gFcioConfig->colourBase, 0, gScreenSize * 2);
+
+    HOTREG &= 127; // disable hotreg
+
+    if (extraRows > 0)
+    {
+        adjustBorders(extraRows, 0);
+    }
+
+    // move colour RAM because of stupid CBDOS himem usage
+    POKE(53348u, COLOUR_RAM_OFFSET & 0xff);
+    POKE(53349u, (COLOUR_RAM_OFFSET >> 8) & 0xff);
+
+    CHRCOUNT = gScreenColumns;
+    LINESTEP_LO = gScreenColumns * 2; // *2 to have 2 screen bytes == 1 character
+    LINESTEP_HI = 0;
+
+    SCNPTR_0 = gFcioConfig->screenBase & 0xff; // screen to 0x12000
+    SCNPTR_1 = (gFcioConfig->screenBase >> 8) & 0xff;
+    SCNPTR_2 = (gFcioConfig->screenBase >> 16) & 0xff;
+    SCNPTR_3 &= 0xF0 | ((gFcioConfig->screenBase) << 24 & 0xff);
+
+    fc_resetwin();
+    fc_clrscr();
+}
+
+void fc_go8bit()
+{
+    mega65_io_enable();
+    VIC3CTRL = 96;    // quit bitplane mode if set
+    POKE(53297L, 96); // quit bitplane mode
+    SCNPTR_0 = 0x00;  // screen back to 0x800
+    SCNPTR_1 = 0x08;
+    SCNPTR_2 = 0x00;
+    SCNPTR_3 &= 0xF0;
+    VIC4CTRL &= 0xFA; // clear fchi and 16bit chars
+    CHRCOUNT = 40;
+    LINESTEP_LO = 40;
+    LINESTEP_HI = 0;
+    HOTREG |= 0x80;   // enable hotreg
+    VIC3CTRL &= 0x7f; // disable H640
+    VIC3CTRL &= 0xf7; // disable V400
+    cbm_k_bsout(14);  // lowercase charset
+    fc_setPalette(0, 0, 0, 0);
+    fc_setPalette(1, 255, 255, 255);
+    fc_setPalette(2, 255, 0, 0);
+}
+
+void fc_plotExtChar(byte x, byte y, byte c)
+{
+    word charIdx;
+    long adr;
+    charIdx = (gFcioConfig->reservedBitmapBase / 64) + c;
+    adr = (x * 2) + (y * gScreenColumns * 2);
+    lpoke(gFcioConfig->screenBase + adr, charIdx % 256);
+    lpoke(gFcioConfig->screenBase + adr + 1, charIdx / 256);
+}
+
+void fc_addGraphicsRect(byte x0, byte y0, byte width, byte height,
+                        himemPtr bitmapData)
+{
+    static byte x, y;
+    long adr;
+    word currentCharIdx;
+
+    currentCharIdx = bitmapData / 64;
+
+    for (y = y0; y < y0 + height; ++y)
+    {
+        for (x = x0; x < x0 + width; ++x)
+        {
+            adr = gFcioConfig->screenBase + (x * 2) + (y * gScreenColumns * 2);
+            lpoke(adr + 1, currentCharIdx / 256); // set highbyte first to avoid blinking
+            lpoke(adr, currentCharIdx % 256);     // while setting up the screeen
+            currentCharIdx++;
+        }
+    }
+}
+
+fciInfo *fc_loadFCI(char *filename, himemPtr address, himemPtr paletteAddress)
+{
+    static byte numColumns, numRows, numColours;
+    static byte fciOptions;
+    static byte reservedSysPalette;
+
+    FILE *fcifile;
+    byte *palette;
+    word palsize;
+    word imgsize;
+    word bytesRead;
+    himemPtr bitmampAdr;
+    himemPtr palAdr;
+    fciInfo *info;
+
+    info = NULL;
+
+    if (!address)
+    {
+        info = (fciInfo *)malloc(sizeof(fciInfo));
+        infoBlocks[infoBlockCount++] = info;
+    }
+
+    fcifile = fopen(filename, "rb");
+
+    if (!fcifile)
+    {
+        fc_fatal("fci not found %s", filename);
+    }
+    fread(fcbuf, 1, 9, fcifile);
+
+    numRows = fcbuf[5];
+    numColumns = fcbuf[6];
+    fciOptions = fcbuf[7];
+    numColours = fcbuf[8];
+    reservedSysPalette = fciOptions & 2;
+
+    palsize = numColours * 3;
+    palette = (byte *)malloc(palsize);
+    fread(palette, 3, numColours, fcifile);
+
+    if (!paletteAddress)
+    {
+        palAdr = fc_allocPalMem(palsize);
+        if (palAdr == 0)
+        {
+            fc_fatal("no room for palette");
+        }
+    }
+    else
+    {
+        palAdr = paletteAddress;
+    }
+    lcopy((long)palette, palAdr, palsize);
+    free(palette);
+    imgsize = numColumns * numRows * 64;
+
+    fread(fcbuf, 1, 3, fcifile);
+    if (0 != memcmp(fcbuf, "img", 3))
+    {
+        fc_fatal("image marker not found in %s", filename);
+    }
+
+    if (!address)
+    {
+        bitmampAdr = fc_allocGraphMem(imgsize);
+        if (bitmampAdr == 0)
+        {
+            fc_fatal("no memory for %s", filename);
+        }
+    }
+    else
+    {
+        bitmampAdr = address;
+    }
+
+    bytesRead = readExt(fcifile, bitmampAdr, false);
+    fclose(fcifile);
+
+    if (info != NULL)
+    {
+        info->columns = numColumns;
+        info->rows = numRows;
+        info->size = bytesRead;
+        info->baseAdr = bitmampAdr;
+        info->paletteAdr = palAdr;
+        info->paletteSize = numColours;
+        info->reservedSysPalette = reservedSysPalette;
+    }
+
+    mega65_io_enable(); // kernal has the disgusting habit of resetting vic personality
+
+    return info;
+}
+
+void fc_zeroPalette(byte reservedSysPalette)
+{
+    byte start;
+
+    mega65_io_enable();
+    start = reservedSysPalette ? 16 : 0;
+    for (cgi = start; cgi < 255; ++cgi)
+    {
+        POKE(0xd100u + cgi, 0); // palette[colAdr];
+        POKE(0xd200u + cgi, 0); // palette[colAdr + 1];
+        POKE(0xd300u + cgi, 0); // palette[colAdr + 2];
+    }
+}
+
+void fc_loadPalette(himemPtr adr, byte size, byte reservedSysPalette)
+{
+    himemPtr colAdr;
+    byte start;
+    start = reservedSysPalette ? 16 : 0;
+
+    for (cgi = start; cgi < size; ++cgi)
+    {
+        colAdr = cgi * 3;
+        POKE(0xd100u + cgi, nyblswap(lpeek(adr + colAdr)));     //  palette[colAdr];
+        POKE(0xd200u + cgi, nyblswap(lpeek(adr + colAdr + 1))); // palette[colAdr + 1];
+        POKE(0xd300u + cgi, nyblswap(lpeek(adr + colAdr + 2))); // palette[colAdr + 2];
+    }
+}
+
+void fc_fadePalette(himemPtr adr, byte size, byte reservedSysPalette, byte steps, bool fadeOut)
+{
+    byte i;
+    byte startReg;
+    byte *destPalette;
+    byte *entry;
+
+    byte start, end, step;
+
+    startReg = reservedSysPalette ? 16 : 0;
+    destPalette = malloc(size * 3);
+    lcopy(adr, (long)destPalette, size * 3);
+
+    if (fadeOut)
+    {
+        start = steps;
+        end = 0;
+        step = -1;
+    }
+    else
+    {
+        start = 0;
+        end = steps;
+        step = 1;
+    }
+
+    for (i = start; i != end; i += step)
+    {
+        entry = destPalette + (startReg * 3);
+        for (cgi = startReg; cgi < size; ++cgi, entry += 3)
+        {
+            POKE(0xd100u + cgi, nyblswap((*(entry)*i) / steps));
+            POKE(0xd200u + cgi, nyblswap((*(entry + 1) * i) / steps));
+            POKE(0xd300u + cgi, nyblswap((*(entry + 2) * i) / steps));
+        }
+    }
+    free(destPalette);
+}
+
+void fc_fadeFCI(fciInfo *info, byte x0, byte y0, byte steps)
+{
+    fc_zeroPalette(info->reservedSysPalette);
+    fc_addGraphicsRect(x0, y0, info->columns, info->rows, info->baseAdr);
+    fc_fadePalette(info->paletteAdr, info->paletteSize, info->reservedSysPalette, steps, false);
+}
+
+void fc_displayFCI(fciInfo *info, byte x0, byte y0, bool setPalette)
+{
+    fc_addGraphicsRect(x0, y0, info->columns, info->rows, info->baseAdr);
+    if (setPalette)
+    {
+        fc_loadFCIPalette(info);
+    }
+}
+
+void fc_loadFCIPalette(fciInfo *info)
+{
+    fc_loadPalette(info->paletteAdr, info->paletteSize,
+                   info->reservedSysPalette);
+}
+
+fciInfo *fc_displayFCIFile(char *filename, byte x0, byte y0)
+{
+    fciInfo *info;
+    info = fc_loadFCI(filename, 0, 0);
+    fc_displayFCI(info, x0, y0, true);
+    return info;
+}
+
+void fc_scrollUp()
+{
+    static byte y;
+    long bas0, bas1;
+    for (y = gCurrentWin->y0; y < gCurrentWin->y0 + gCurrentWin->height - 1; y++)
+    {
+        bas0 = gFcioConfig->screenBase + (gCurrentWin->x0 * 2 + (y * gScreenColumns * 2));
+        bas1 = gFcioConfig->screenBase + (gCurrentWin->x0 * 2 + ((y + 1) * gScreenColumns * 2));
+        lcopy(bas1, bas0, gCurrentWin->width * 2);
+        bas0 = gFcioConfig->colourBase + (gCurrentWin->x0 * 2 + (y * gScreenColumns * 2));
+        bas1 = gFcioConfig->colourBase + (gCurrentWin->x0 * 2 + ((y + 1) * gScreenColumns * 2));
+        lcopy(bas1, bas0, gCurrentWin->width * 2);
+    }
+    fc_line(0, gCurrentWin->height - 1, gCurrentWin->width, 32, gCurrentWin->textcolor);
+}
+
+void fc_scrollDown()
+{
+    signed char y;
+    long bas0, bas1;
+    for (y = gCurrentWin->y0 + gCurrentWin->height - 2;
+         y >= gCurrentWin->y0; y--)
+    {
+        bas0 = gFcioConfig->screenBase + (gCurrentWin->x0 * 2 + (y * gScreenColumns * 2));
+        bas1 = gFcioConfig->screenBase + (gCurrentWin->x0 * 2 + ((y + 1) * gScreenColumns * 2));
+        lcopy(bas0, bas1, gCurrentWin->width * 2);
+        bas0 = gFcioConfig->colourBase + (gCurrentWin->x0 * 2 + (y * gScreenColumns * 2));
+        bas1 = gFcioConfig->colourBase + (gCurrentWin->x0 * 2 + ((y + 1) * gScreenColumns * 2));
+        lcopy(bas0, bas1, gCurrentWin->width * 2);
+    }
+
+    fc_line(0, 0, gCurrentWin->width, 32, gCurrentWin->textcolor);
+}
+
+void cr()
+{
+    gCurrentWin->xc = 0;
+    gCurrentWin->yc++;
+    if (gCurrentWin->yc > gCurrentWin->height - 1)
+    {
+        fc_scrollUp();
+        gCurrentWin->yc = gCurrentWin->height - 1;
+    }
+}
+
+void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr)
+{
+    word adrOffset;
+    adrOffset = (x * 2) + (y * 2 * gScreenColumns);
+    lpoke(gFcioConfig->screenBase + adrOffset, c);
+    lpoke(gFcioConfig->screenBase + adrOffset + 1, 0);
+    lpoke(gFcioConfig->colourBase + adrOffset + 1, color | exAttr);
+    lpoke(gFcioConfig->colourBase + adrOffset, 0);
+}
+
+byte fc_wherex() { return gCurrentWin->xc; }
+
+byte fc_wherey() { return gCurrentWin->yc; }
+
+void fc_putc(char c)
+{
+    static char out;
+    if (!c)
+    {
+        return;
+    }
+    if (c == '\n')
+    {
+        cr();
+        return;
+    }
+
+    if (gCurrentWin->xc >= gCurrentWin->width)
+    {
+        return;
+    }
+
+    out = asciiToPetscii(c);
+
+    fc_plotPetsciiChar(gCurrentWin->xc + gCurrentWin->x0, gCurrentWin->yc + gCurrentWin->y0, out,
+                       gCurrentWin->textcolor, gCurrentWin->extAttributes);
+    gCurrentWin->xc++;
+
+    if (autoCR)
+    {
+        if (gCurrentWin->xc >= gCurrentWin->width)
+        {
+            gCurrentWin->yc++;
+            gCurrentWin->xc = 0;
+            if (gCurrentWin->yc > gCurrentWin->height)
+            {
+                gCurrentWin->yc = gCurrentWin->height;
+                fc_scrollUp();
+            }
+        }
+    }
+
+    if (csrflag)
+    {
+        fc_plotPetsciiChar(gCurrentWin->xc + gCurrentWin->x0, gCurrentWin->yc + gCurrentWin->y0,
+                           CURSOR_CHARACTER, gCurrentWin->textcolor, 16);
+    }
+}
+
+void _debug_fc_puts(const char *s)
+{
+    const char *current = s;
+    while (*current)
+    {
+        fc_putc(*current++);
+    }
+}
+
+void fc_puts(const char *s)
+{
+    /* #ifdef DEBUG
+    char out[16];
+#endif */
+    const char *current = s;
+    while (*current)
+    {
+        fc_putc(*current++);
+    }
+    /* #ifdef DEBUG
+    gCurrentWin->x0 = 0;
+    gCurrentWin->y0 = 0;
+    gCurrentWin->xc = gScreenColumns - 4;
+    gCurrentWin->yc = 0;
+    sprintf(out, "%x", _heapmaxavail());
+    _debug_fc_puts(out);
+#endif */
+}
+
+void fc_putsxy(byte x, byte y, char *s)
+{
+    fc_gotoxy(x, y);
+    fc_puts(s);
+}
+
+void fc_putcxy(byte x, byte y, char c)
+{
+    fc_gotoxy(x, y);
+    fc_putc(c);
+}
+
+void fc_cursor(byte onoff)
+{
+    csrflag = onoff;
+
+    fc_plotPetsciiChar(gCurrentWin->xc + gCurrentWin->x0,
+                       gCurrentWin->yc + gCurrentWin->y0,
+                       (csrflag ? CURSOR_CHARACTER : 32),
+                       gCurrentWin->textcolor,
+                       (csrflag ? 16 : 0));
+}
+
+void fc_textcolor(byte c) { gCurrentWin->textcolor = c; }
+
+void fc_gotoxy(byte x, byte y)
+{
+    gCurrentWin->xc = x;
+    gCurrentWin->yc = y;
+}
+
+void fc_printf(const char *format, ...)
+{
+    char buf[160];
+    va_list args;
+    va_start(args, format);
+    vsprintf(buf, format, args);
+    va_end(args);
+    fc_puts(buf);
+}
+
+void fc_clrscr()
+{
+    fc_block(0, 0, gCurrentWin->width, gCurrentWin->height, 32,
+             gCurrentWin->textcolor);
+    fc_gotoxy(0, 0);
+}
+
+void fc_resetwin()
+{
+    gCurrentWin = defaultWin;
+    gCurrentWin->x0 = 0;
+    gCurrentWin->y0 = 0;
+    gCurrentWin->width = gScreenColumns;
+    gCurrentWin->height = gScreenRows;
+    gCurrentWin->xc = 0;
+    gCurrentWin->yc = 0;
+    gCurrentWin->extAttributes = 0;
+    gCurrentWin->textcolor = 5;
+}
+
+void fc_setwin(textwin *aWin)
+{
+    gCurrentWin = aWin;
+}
+
+textwin *fc_makeWin(byte x0, byte y0, byte width, byte height)
+{
+    textwin *aWin;
+    aWin = malloc(sizeof(textwin));
+    aWin->x0 = x0;
+    aWin->y0 = y0;
+    aWin->width = width;
+    aWin->height = height;
+    aWin->xc = 0;
+    aWin->yc = 0;
+    aWin->extAttributes = 0;
+    aWin->textcolor = 5; // because I like green. your mileage may vary.
+    return aWin;
+}
+
+int fc_kbhit()
+{
+    // TODO: implement m65 native keyboard scan
+    return kbhit();
+}
+
+void fc_emptyBuffer(void)
+{
+    while (kbhit())
+    {
+        cgetc();
+    }
+}
+
+unsigned char fc_cgetc(void)
+{
+    return cgetc();
+}
+
+char fc_getkey(void)
+{
+    fc_emptyBuffer();
+    return cgetc();
+}
+
+int fc_getnum(byte maxlen)
+{
+    int res;
+    char *inptr;
+    inptr = fc_input(maxlen);
+    res = atoi(inptr);
+    free(inptr);
+    return res;
+}
+
+char *fc_input(byte maxlen)
+{
+    static byte len, ct;
+    char current;
+    char *ret;
+    len = 0;
+    ct = csrflag;
+    fc_cursor(1);
+    do
+    {
+        current = cgetc();
+        if (current != '\n')
+        {
+            if (current >= 32)
+            {
+                if (len < maxlen)
+                {
+                    fcbuf[len] = current;
+                    fcbuf[len + 1] = 0;
+                    fc_putc(current);
+                    ++len;
+                }
+            }
+            else if (current == 20)
+            {
+                // del pressed
+                if (len > 0)
+                {
+                    fc_cursor(0);
+                    fc_gotoxy(gCurrentWin->xc - 1, gCurrentWin->yc);
+                    fc_putc(' ');
+                    fc_gotoxy(gCurrentWin->xc - 1, gCurrentWin->yc);
+                    fc_cursor(1);
+                    --len;
+                }
+            }
+        }
+    } while (current != '\n');
+    ret = (char *)malloc(++len);
+    if (len == 1)
+    {
+        *ret = 0;
+    }
+    else
+    {
+        strncpy(ret, fcbuf, len);
+    }
+    fc_cursor(ct);
+    return ret;
+}
+
+void fc_line(byte x, byte y, byte width, byte character, byte col)
+{
+    word bas;
+
+    bas = (gCurrentWin->x0 + x) * 2 + ((gCurrentWin->y0 + y) * gScreenColumns * 2);
+
+    // use DMAgic to fill FCM screens with skip byte... PGS, I love you!
+    lfill_skip(gFcioConfig->screenBase + bas, character, width, 2);
+    lfill_skip(gFcioConfig->screenBase + bas + 1, 0, width, 2);
+    lfill_skip(gFcioConfig->colourBase + bas, 0, width, 2);
+    lfill_skip(gFcioConfig->colourBase + bas + 1, col, width, 2);
+
+    return;
+}
+
+void fc_block(byte x0, byte y0, byte width, byte height, byte character,
+              byte col)
+{
+    static byte y;
+    for (y = 0; y < height; ++y)
+    {
+        fc_line(x0, y0 + y, width, character, col);
+    }
+}
+
+void fc_center(byte x, byte y, byte width, char *text)
+{
+    static byte l;
+    l = strlen(text);
+    if (l >= width - 2)
+    {
+        fc_gotoxy(x, y);
+        fc_puts(text);
+        return;
+    }
+    fc_gotoxy(-1 + x + width / 2 - l / 2, y);
+    fc_puts(text);
+}
+
+void fc_setPalette(byte num, byte red, byte green, byte blue)
+{
+    POKE(0xd100U + num, nyblswap(red));
+    POKE(0xd200U + num, nyblswap(green));
+    POKE(0xd300U + num, nyblswap(blue));
+}
+
+char fc_getkeyP(byte x, byte y, const char *prompt)
+{
+    fc_emptyBuffer();
+    fc_gotoxy(x, y);
+    fc_textcolor(COLOR_WHITE);
+    fc_puts(prompt);
+    return cgetc();
+}
+
+void fc_hlinexy(byte x, byte y, byte width, byte lineChar)
+{
+    for (cgi = x; cgi < x + width; cgi++)
+    {
+        fc_plotExtChar(gCurrentWin->x0 + x + cgi, gCurrentWin->y0 + y, lineChar);
+    }
+}
+
+void fc_vlinexy(byte x, byte y, byte height, byte lineChar)
+{
+    for (cgi = y; cgi < y + height; cgi++)
+    {
+        fc_plotExtChar(gCurrentWin->x0 + x, gCurrentWin->y0 + y + cgi, lineChar);
+    }
+}

--- a/cc65/src/memory.c
+++ b/cc65/src/memory.c
@@ -13,12 +13,12 @@ void do_dma(void)
   //    printf("%02x ",PEEK(i+(unsigned int)&dmalist));
   //  printf("\n");
   //  while(1) continue;
-  
+
   // Now run DMA job (to and from anywhere, and list is in low 1MB)
-  POKE(0xd702U,0);
-  POKE(0xd704U,0x00);  // List is in $00xxxxx
-  POKE(0xd701U,((unsigned int)&dmalist)>>8);
-  POKE(0xd705U,((unsigned int)&dmalist)&0xff); // triggers enhanced DMA
+  POKE(0xd702U, 0);
+  POKE(0xd704U, 0x00); // List is in $00xxxxx
+  POKE(0xd701U, ((unsigned int)&dmalist) >> 8);
+  POKE(0xd705U, ((unsigned int)&dmalist) & 0xff); // triggers enhanced DMA
 }
 
 unsigned char lpeek(long address)
@@ -28,86 +28,93 @@ unsigned char lpeek(long address)
   // (separate DMA lists for peek, poke and copy should
   // save space, since most fields can stay initialised).
 
-  dmalist.option_0b=0x0b;
-  dmalist.option_80=0x80;
-  dmalist.source_mb=(address>>20);
-  dmalist.option_81=0x81;
-  dmalist.dest_mb=0x00; // dma_byte lives in 1st MB
-  dmalist.end_of_options=0x00;
-  dmalist.sub_cmd=0x00;
-  
-  dmalist.command=0x00; // copy
-  dmalist.count=1;
-  dmalist.source_addr=address&0xffff;
-  dmalist.source_bank=(address>>16)&0x0f;
-  dmalist.dest_addr=(unsigned int)&dma_byte;
-  dmalist.dest_bank=0;
+  dmalist.option_0b = 0x0b;
+  dmalist.option_80 = 0x80;
+  dmalist.source_mb = (address >> 20);
+  dmalist.option_81 = 0x81;
+  dmalist.dest_mb = 0x00; // dma_byte lives in 1st MB
+  dmalist.option_85 = 0x85;
+  dmalist.dest_skip = 1;
+  dmalist.end_of_options = 0x00;
+  dmalist.sub_cmd = 0x00;
+
+  dmalist.command = 0x00; // copy
+  dmalist.count = 1;
+  dmalist.source_addr = address & 0xffff;
+  dmalist.source_bank = (address >> 16) & 0x0f;
+  dmalist.dest_addr = (unsigned int)&dma_byte;
+  dmalist.dest_bank = 0;
 
   do_dma();
 
   return dma_byte;
 }
 
-unsigned char db1,db2,db3;
+unsigned char db1, db2, db3;
 
 unsigned char lpeek_debounced(long address)
 {
-  db1=0; db2=1;
-  while(db1!=db2||db1!=db3) {
-    db1=lpeek(address);
-    db2=lpeek(address);
-    db3=lpeek(address);
+  db1 = 0;
+  db2 = 1;
+  while (db1 != db2 || db1 != db3)
+  {
+    db1 = lpeek(address);
+    db2 = lpeek(address);
+    db3 = lpeek(address);
   }
   return db1;
 }
 
-
 void lpoke(long address, unsigned char value)
-{  
+{
 
-  dmalist.option_0b=0x0b;
-  dmalist.option_80=0x80;
-  dmalist.source_mb=0x00; // dma_byte lives in 1st MB
-  dmalist.option_81=0x81;
-  dmalist.dest_mb=(address>>20);
-  dmalist.end_of_options=0x00;
-  dmalist.sub_cmd=0x00;
-  
-  dma_byte=value;
-  dmalist.command=0x00; // copy
-  dmalist.count=1;
-  dmalist.source_addr=(unsigned int)&dma_byte;
-  dmalist.source_bank=0;
-  dmalist.dest_addr=address&0xffff;
-  dmalist.dest_bank=(address>>16)&0x0f;
+  dmalist.option_0b = 0x0b;
+  dmalist.option_80 = 0x80;
+  dmalist.source_mb = 0x00; // dma_byte lives in 1st MB
+  dmalist.option_81 = 0x81;
+  dmalist.dest_mb = (address >> 20);
+  dmalist.option_85 = 0x85;
+  dmalist.dest_skip = 1;
+  dmalist.end_of_options = 0x00;
+  dmalist.sub_cmd = 0x00;
 
-  do_dma(); 
+  dma_byte = value;
+  dmalist.command = 0x00; // copy
+  dmalist.count = 1;
+  dmalist.source_addr = (unsigned int)&dma_byte;
+  dmalist.source_bank = 0;
+  dmalist.dest_addr = address & 0xffff;
+  dmalist.dest_bank = (address >> 16) & 0x0f;
+
+  do_dma();
   return;
 }
 
 void lcopy(long source_address, long destination_address,
-	  unsigned int count)
+           unsigned int count)
 {
-  dmalist.option_0b=0x0b;
-  dmalist.option_80=0x80;
-  dmalist.source_mb=source_address>>20;
-  dmalist.option_81=0x81;
-  dmalist.dest_mb=(destination_address>>20);
-  dmalist.end_of_options=0x00;
-  dmalist.sub_cmd=0x00;
+  dmalist.option_0b = 0x0b;
+  dmalist.option_80 = 0x80;
+  dmalist.source_mb = source_address >> 20;
+  dmalist.option_81 = 0x81;
+  dmalist.dest_mb = (destination_address >> 20);
+  dmalist.option_85 = 0x85;
+  dmalist.dest_skip = 1;
+  dmalist.end_of_options = 0x00;
+  dmalist.sub_cmd = 0x00;
 
-  dmalist.command=0x00; // copy
-  dmalist.count=count;
-  dmalist.sub_cmd=0;
-  dmalist.source_addr=source_address&0xffff;
-  dmalist.source_bank=(source_address>>16)&0x0f;
+  dmalist.command = 0x00; // copy
+  dmalist.count = count;
+  dmalist.sub_cmd = 0;
+  dmalist.source_addr = source_address & 0xffff;
+  dmalist.source_bank = (source_address >> 16) & 0x0f;
   // User should provide 28-bit address for IO
   // (otherwise we can't DMA to/from RAM under IO)
   //  if (source_address>=0xd000 && source_address<0xe000)
-  //    dmalist.source_bank|=0x80;  
-  dmalist.dest_addr=destination_address&0xffff;
-  dmalist.dest_bank=(destination_address>>16)&0x0f;
-  // User should provide 28-bit address for IO  
+  //    dmalist.source_bank|=0x80;
+  dmalist.dest_addr = destination_address & 0xffff;
+  dmalist.dest_bank = (destination_address >> 16) & 0x0f;
+  // User should provide 28-bit address for IO
   // (otherwise we can't DMA to/from RAM under IO)
   //  if (destination_address>=0xd000 && destination_address<0xe000)
   //    dmalist.dest_bank|=0x80;
@@ -117,22 +124,24 @@ void lcopy(long source_address, long destination_address,
 }
 
 void lfill(long destination_address, unsigned char value,
-	  unsigned int count)
+           unsigned int count)
 {
-  dmalist.option_0b=0x0b;
-  dmalist.option_80=0x80;
-  dmalist.source_mb=0x00;
-  dmalist.option_81=0x81;
-  dmalist.dest_mb=destination_address>>20;
-  dmalist.end_of_options=0x00;
+  dmalist.option_0b = 0x0b;
+  dmalist.option_80 = 0x80;
+  dmalist.source_mb = 0x00;
+  dmalist.option_81 = 0x81;
+  dmalist.dest_mb = destination_address >> 20;
+  dmalist.option_85 = 0x85;
+  dmalist.dest_skip = 1;
+  dmalist.end_of_options = 0x00;
 
-  dmalist.command=0x03; // fill
-  dmalist.sub_cmd=0;
-  dmalist.count=count;
-  dmalist.source_addr=value;
-  dmalist.dest_addr=destination_address&0xffff;
-  dmalist.dest_bank=(destination_address>>16)&0x0f;
-  // User should provide 28-bit address for IO  
+  dmalist.command = 0x03; // fill
+  dmalist.sub_cmd = 0;
+  dmalist.count = count;
+  dmalist.source_addr = value;
+  dmalist.dest_addr = destination_address & 0xffff;
+  dmalist.dest_bank = (destination_address >> 16) & 0x0f;
+  // User should provide 28-bit address for IO
   // (otherwise we can't DMA to/from RAM under IO)
   //  if (destination_address>=0xd000 && destination_address<0xe000)
   //    dmalist.dest_bank|=0x80;
@@ -141,11 +150,34 @@ void lfill(long destination_address, unsigned char value,
   return;
 }
 
+void lfill_skip(long destination_address, unsigned char value,
+                unsigned int count, unsigned char skip)
+{
+  dmalist.option_0b = 0x0b;
+  dmalist.option_80 = 0x80;
+  dmalist.source_mb = 0x00;
+  dmalist.option_81 = 0x81;
+  dmalist.dest_mb = destination_address >> 20;
+  dmalist.option_85 = 0x85;
+  dmalist.dest_skip = skip;
+  dmalist.end_of_options = 0x00;
+
+  dmalist.command = 0x03; // fill
+  dmalist.sub_cmd = 0;
+  dmalist.count = count;
+  dmalist.source_addr = value;
+  dmalist.dest_addr = destination_address & 0xffff;
+  dmalist.dest_bank = (destination_address >> 16) & 0x0f;
+
+  do_dma();
+  return;
+}
+
 void mega65_io_enable(void)
 {
   // Gate C65 IO enable
-  POKE(0xd02fU,0x47);
-  POKE(0xd02fU,0x53);
+  POKE(0xd02fU, 0x47);
+  POKE(0xd02fU, 0x53);
   // Force to full speed
-  POKE(0,65);
+  POKE(0, 65);
 }


### PR DESCRIPTION
This integrates FCIO into mega65-libc.

The only change in mega65-libc itself is the extension of the DMA list with the "skip" option (as FCIO is using this facility to quickly fill screen rows). 

I have written a short demo program [here](https://github.com/steph72/fcio-libc-demo) to demonstrate that fcio.h and conio.h are now able to coexist peacefully. I'm attaching the ready-made .d81 disc image here for evaluation.

[fcdemo.zip](https://github.com/MEGA65/mega65-libc/files/7077816/fcdemo.zip)

![Screenshot from 2021-08-30 17-34-01](https://user-images.githubusercontent.com/51749597/131365055-b08799c5-ec79-4c87-8ef6-9efa8c9ef33a.png)

P.S.: full inline documentation is available in fcio.h