### PR TITLE
Github action for clang cmake build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Download llvm-mos-sdk
+      run: wget https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
+      
+    - name: Unpack llvm-mos-sdk
+      run: tar zxf llvm-mos-linux.tar.xz
+      
+    - name: Go to project clang/ directory
+      run: cd clang/
+
+    - name: Configure CMake
+      run: cmake -DCMAKE_PREFIX_PATH=../llvm-mos .
+
+    - name: Build
+      # Build your program with the given configuration
+      run: make

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
       run: wget https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
       
     - name: Unpack llvm-mos-sdk
-      run: tar zxf llvm-mos-linux.tar.xz
+      run: tar xf llvm-mos-linux.tar.xz
       
     - name: Go to project clang/ directory
       run: cd clang/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,17 +21,21 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Download llvm-mos-sdk
+      working-directory: ${{github.workspace}}
       run: wget https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
-      
+        
     - name: Unpack llvm-mos-sdk
+      working-directory: ${{github.workspace}}
       run: tar xf llvm-mos-linux.tar.xz
       
-    - name: Go to project clang/ directory
-      run: cd clang/
-
+    - name: List working directory
+      working-directory: ${{github.workspace}}
+      run: ls -l
+      
     - name: Configure CMake
-      run: cmake -DCMAKE_PREFIX_PATH=../llvm-mos .
+      working-directory: ${{github.workspace}}/clang/
+      run: cmake -DCMAKE_PREFIX_PATH=${{github.workspace}}/llvm-mos .
 
     - name: Build
-      # Build your program with the given configuration
+      working-directory: ${{github.workspace}}/clang/
       run: make


### PR DESCRIPTION
This adds a github action that checks if building mega65-libc using the latest version of llvm-mos-sdk.