### PR TITLE
Reduce warnings emitted by clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(CLANG_WARNINGS
     -Wformat=2 # warn on security issues around functions that format output (ie printf)
     -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
     -Wpedantic # warn if non-standard C/C++ is used
-    -Wlanguage-extension-token
+    -Wno-language-extension-token
 )
 target_compile_options(mega65libc PRIVATE -Os ${CLANG_WARNINGS})
 

--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -13,7 +13,7 @@ CC65=$(CC65_PREFIX)cc65
 CA65=$(CC65_PREFIX)ca65 --cpu 4510
 AR65=$(CC65_PREFIX)ar65
 
-CFLAGS=-O -t c64 -I include/
+CFLAGS=-O -t c64 -W +unused-param,+error,+unused-label,+no-effect,+unused-var,+no-effect -I include/
 
 LIB_OBJECTS = \
 	src/cc65/dirent.o \

--- a/include/mega65/dirent.h
+++ b/include/mega65/dirent.h
@@ -7,7 +7,11 @@ unsigned char opendir(void);
 struct m65_dirent* readdir(unsigned char);
 void closedir(unsigned char);
 
+#ifdef __clang__
+struct __attribute__((__packed__)) m65_dirent {
+#else
 struct m65_dirent {
+#endif
     uint32_t d_ino;
     uint16_t d_off;
     uint32_t d_reclen;

--- a/include/mega65/hal.h
+++ b/include/mega65/hal.h
@@ -1,10 +1,6 @@
 #ifndef __MEGA65_HAL_H
 #define __MEGA65_HAL_H
 
-#ifdef __CC65__
-#include <sys/types.h>
-#include <ctype.h>
-#endif
 #include <stdint.h>
 
 void usleep(uint32_t micros);

--- a/include/mega65/memory.h
+++ b/include/mega65/memory.h
@@ -5,44 +5,45 @@
 
 struct dmagic_dmalist {
     // Enhanced DMA options
-    unsigned char option_0b;
-    unsigned char option_80;
-    unsigned char source_mb;
-    unsigned char option_81;
-    unsigned char dest_mb;
-    unsigned char option_85;
-    unsigned char dest_skip;
-    unsigned char end_of_options;
+    uint8_t option_0b;
+    uint8_t option_80;
+    uint8_t source_mb;
+    uint8_t option_81;
+    uint8_t dest_mb;
+    uint8_t option_85;
+    uint8_t dest_skip;
+    uint8_t end_of_options;
 
     // F018B format DMA request
-    unsigned char command;
+    uint8_t command;
     unsigned int count;
     unsigned int source_addr;
-    unsigned char source_bank;
+    uint8_t source_bank;
     unsigned int dest_addr;
-    unsigned char dest_bank;
-    unsigned char sub_cmd; // F018B subcmd
+    uint8_t dest_bank;
+    uint8_t sub_cmd; // F018B subcmd
     unsigned int modulo;
 };
 
 #ifdef __clang__
 extern volatile struct dmagic_dmalist dmalist;
-extern volatile unsigned char dma_byte;
+extern volatile uint8_t dma_byte;
 #else
 extern struct dmagic_dmalist dmalist;
-extern unsigned char dma_byte;
+extern uint8_t dma_byte;
 #endif
 
 void mega65_io_enable(void);
-unsigned char lpeek(uint32_t address);
-unsigned char lpeek_debounced(uint32_t address);
-unsigned char dma_peek(uint32_t address);
-void lpoke(uint32_t address, unsigned char value);
-void dma_poke(uint32_t address, unsigned char value);
-void lcopy(uint32_t source_address, uint32_t destination_address, unsigned int count);
-void lfill(uint32_t destination_address, unsigned char value, unsigned int count);
-void lfill_skip(uint32_t destination_address, unsigned char value,
-    unsigned int count, unsigned char skip);
+uint8_t lpeek(uint32_t address);
+uint8_t lpeek_debounced(uint32_t address);
+uint8_t dma_peek(uint32_t address);
+void lpoke(uint32_t address, uint8_t value);
+void dma_poke(uint32_t address, uint8_t value);
+void lcopy(
+    uint32_t source_address, uint32_t destination_address, unsigned int count);
+void lfill(uint32_t destination_address, uint8_t value, unsigned int count);
+void lfill_skip(uint32_t destination_address, uint8_t value, unsigned int count,
+    uint8_t skip);
 
 #ifdef __clang__
 #define POKE(X, Y) (*(volatile uint8_t*)(X)) = Y

--- a/include/mega65/memory.h
+++ b/include/mega65/memory.h
@@ -3,7 +3,11 @@
 
 #include <stdint.h>
 
+#ifdef __clang__
+struct __attribute__((__packed__)) dmagic_dmalist {
+#else
 struct dmagic_dmalist {
+#endif
     // Enhanced DMA options
     uint8_t option_0b;
     uint8_t option_80;
@@ -16,13 +20,13 @@ struct dmagic_dmalist {
 
     // F018B format DMA request
     uint8_t command;
-    unsigned int count;
-    unsigned int source_addr;
+    uint16_t count;
+    uint16_t source_addr;
     uint8_t source_bank;
-    unsigned int dest_addr;
+    uint16_t dest_addr;
     uint8_t dest_bank;
     uint8_t sub_cmd; // F018B subcmd
-    unsigned int modulo;
+    uint16_t modulo;
 };
 
 #ifdef __clang__
@@ -40,10 +44,10 @@ uint8_t dma_peek(uint32_t address);
 void lpoke(uint32_t address, uint8_t value);
 void dma_poke(uint32_t address, uint8_t value);
 void lcopy(
-    uint32_t source_address, uint32_t destination_address, unsigned int count);
-void lfill(uint32_t destination_address, uint8_t value, unsigned int count);
-void lfill_skip(uint32_t destination_address, uint8_t value, unsigned int count,
-    uint8_t skip);
+    uint32_t source_address, uint32_t destination_address, uint16_t count);
+void lfill(uint32_t destination_address, uint8_t value, uint16_t count);
+void lfill_skip(
+    uint32_t destination_address, uint8_t value, uint16_t count, uint8_t skip);
 
 #ifdef __clang__
 #define POKE(X, Y) (*(volatile uint8_t*)(X)) = Y

--- a/include/mega65/memory.h
+++ b/include/mega65/memory.h
@@ -34,14 +34,14 @@ extern unsigned char dma_byte;
 #endif
 
 void mega65_io_enable(void);
-unsigned char lpeek(long address);
-unsigned char lpeek_debounced(long address);
-unsigned char dma_peek(long address);
-void lpoke(long address, unsigned char value);
-void dma_poke(long address, unsigned char value);
-void lcopy(long source_address, long destination_address, unsigned int count);
-void lfill(long destination_address, unsigned char value, unsigned int count);
-void lfill_skip(long destination_address, unsigned char value,
+unsigned char lpeek(uint32_t address);
+unsigned char lpeek_debounced(uint32_t address);
+unsigned char dma_peek(uint32_t address);
+void lpoke(uint32_t address, unsigned char value);
+void dma_poke(uint32_t address, unsigned char value);
+void lcopy(uint32_t source_address, uint32_t destination_address, unsigned int count);
+void lfill(uint32_t destination_address, unsigned char value, unsigned int count);
+void lfill_skip(uint32_t destination_address, unsigned char value,
     unsigned int count, unsigned char skip);
 
 #ifdef __clang__

--- a/include/mega65/sdcard.h
+++ b/include/mega65/sdcard.h
@@ -1,7 +1,7 @@
-#include <mega65/hal.h>
-
 #ifndef __MEGA65_SDCARD_H
 #define __MEGA65_SDCARD_H
+
+#include <stdint.h>
 
 extern uint8_t sector_buffer[512];
 

--- a/include/mega65/time.h
+++ b/include/mega65/time.h
@@ -9,7 +9,11 @@
 #ifndef __MEGA65_TIME_H
 #define __MEGA65_TIME_H
 
+#ifdef __clang__
+struct __attribute__((__packed__)) m65_tm {
+#else
 struct m65_tm {
+#endif
     unsigned char tm_sec;   /* Seconds (0-60) */
     unsigned char tm_min;   /* Minutes (0-59) */
     unsigned char tm_hour;  /* Hours (0-23) */

--- a/src/fat32.c
+++ b/src/fat32.c
@@ -28,14 +28,14 @@ long mega65_fat32_create_contiguous_file(char* name, long size,
     unsigned int fat_offset = 0;
     int j;
 
-    clusters = size / 4096;
+    clusters = (unsigned short)(size / 4096);
     if (size & 4095) {
         clusters++;
     }
 
     for (fat_offset = 0; fat_offset <= (fat2_sector - fat1_sector);
          fat_offset++) {
-        mega65_sdcard_readsector(fat1_sector + fat_offset);
+        mega65_sdcard_readsector((uint32_t)(fat1_sector + fat_offset));
         contiguous_clusters = 0;
         start_cluster = 0;
 
@@ -138,5 +138,5 @@ long mega65_fat32_create_contiguous_file(char* name, long size,
 
     mega65_sdcard_writesector(root_dir_sector);
 
-    return root_dir_sector + (start_cluster - 2) * 8;
+    return root_dir_sector + (long)(start_cluster - 2) * 8;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -3,10 +3,10 @@
 
 #ifdef __clang__
 volatile struct dmagic_dmalist dmalist;
-volatile unsigned char dma_byte;
+volatile uint8_t dma_byte;
 #else
 struct dmagic_dmalist dmalist;
-unsigned char dma_byte;
+uint8_t dma_byte;
 #endif
 
 void do_dma(void)
@@ -26,7 +26,7 @@ void do_dma(void)
     POKE(0xd705U, ((unsigned int)&dmalist) & 0xff); // triggers enhanced DMA
 }
 
-unsigned char dma_peek(uint32_t address)
+uint8_t dma_peek(uint32_t address)
 {
     // Read the byte at <address> in 28-bit address space
     // XXX - Optimise out repeated setup etc
@@ -55,9 +55,9 @@ unsigned char dma_peek(uint32_t address)
     return dma_byte;
 }
 
-unsigned char db1, db2, db3;
+uint8_t db1, db2, db3;
 
-unsigned char lpeek_debounced(uint32_t address)
+uint8_t lpeek_debounced(uint32_t address)
 {
     db1 = 0;
     db2 = 1;
@@ -71,17 +71,17 @@ unsigned char lpeek_debounced(uint32_t address)
 
 // cc65 and llvm have specialized assembler versions of lpeek and lpoke
 #if !defined(__clang__) && !defined(__CC65__)
-unsigned char lpeek(uint32_t address)
+uint8_t lpeek(uint32_t address)
 {
     return dma_peek(address);
 }
-void lpoke(uint32_t address, unsigned char value)
+void lpoke(uint32_t address, uint8_t value)
 {
     dma_poke(address, value);
 }
 #endif
 
-void dma_poke(uint32_t address, unsigned char value)
+void dma_poke(uint32_t address, uint8_t value)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -138,7 +138,7 @@ void lcopy(
     return;
 }
 
-void lfill(uint32_t destination_address, unsigned char value, unsigned int count)
+void lfill(uint32_t destination_address, uint8_t value, unsigned int count)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -164,8 +164,8 @@ void lfill(uint32_t destination_address, unsigned char value, unsigned int count
     return;
 }
 
-void lfill_skip(uint32_t destination_address, unsigned char value,
-    unsigned int count, unsigned char skip)
+void lfill_skip(uint32_t destination_address, uint8_t value, unsigned int count,
+    uint8_t skip)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;

--- a/src/memory.c
+++ b/src/memory.c
@@ -15,15 +15,15 @@ void do_dma(void)
     mega65_io_enable();
 
     //  for(i=0;i<24;i++)
-    //    printf("%02x ",PEEK(i+(unsigned int)&dmalist));
+    //    printf("%02x ",PEEK(i+(uint16_t)&dmalist));
     //  printf("\n");
     //  while(1) continue;
 
     // Now run DMA job (to and from anywhere, and list is in low 1MB)
     POKE(0xd702U, 0);
     POKE(0xd704U, 0x00); // List is in $00xxxxx
-    POKE(0xd701U, ((unsigned int)&dmalist) >> 8);
-    POKE(0xd705U, ((unsigned int)&dmalist) & 0xff); // triggers enhanced DMA
+    POKE(0xd701U, ((uint16_t)&dmalist) >> 8);
+    POKE(0xd705U, ((uint16_t)&dmalist) & 0xff); // triggers enhanced DMA
 }
 
 uint8_t dma_peek(uint32_t address)
@@ -47,7 +47,7 @@ uint8_t dma_peek(uint32_t address)
     dmalist.count = 1;
     dmalist.source_addr = address & 0xffff;
     dmalist.source_bank = (address >> 16) & 0x0f;
-    dmalist.dest_addr = (unsigned int)&dma_byte;
+    dmalist.dest_addr = (uint16_t)&dma_byte;
     dmalist.dest_bank = 0;
 
     do_dma();
@@ -96,7 +96,7 @@ void dma_poke(uint32_t address, uint8_t value)
     dma_byte = value;
     dmalist.command = 0x00; // copy
     dmalist.count = 1;
-    dmalist.source_addr = (unsigned int)&dma_byte;
+    dmalist.source_addr = (uint16_t)&dma_byte;
     dmalist.source_bank = 0;
     dmalist.dest_addr = address & 0xffff;
     dmalist.dest_bank = (address >> 16) & 0x0f;
@@ -106,7 +106,7 @@ void dma_poke(uint32_t address, uint8_t value)
 }
 
 void lcopy(
-    uint32_t source_address, uint32_t destination_address, unsigned int count)
+    uint32_t source_address, uint32_t destination_address, uint16_t count)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -138,7 +138,7 @@ void lcopy(
     return;
 }
 
-void lfill(uint32_t destination_address, uint8_t value, unsigned int count)
+void lfill(uint32_t destination_address, uint8_t value, uint16_t count)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -164,7 +164,7 @@ void lfill(uint32_t destination_address, uint8_t value, unsigned int count)
     return;
 }
 
-void lfill_skip(uint32_t destination_address, uint8_t value, unsigned int count,
+void lfill_skip(uint32_t destination_address, uint8_t value, uint16_t count,
     uint8_t skip)
 {
     dmalist.option_0b = 0x0b;

--- a/src/memory.c
+++ b/src/memory.c
@@ -26,7 +26,7 @@ void do_dma(void)
     POKE(0xd705U, ((unsigned int)&dmalist) & 0xff); // triggers enhanced DMA
 }
 
-unsigned char dma_peek(long address)
+unsigned char dma_peek(uint32_t address)
 {
     // Read the byte at <address> in 28-bit address space
     // XXX - Optimise out repeated setup etc
@@ -57,7 +57,7 @@ unsigned char dma_peek(long address)
 
 unsigned char db1, db2, db3;
 
-unsigned char lpeek_debounced(long address)
+unsigned char lpeek_debounced(uint32_t address)
 {
     db1 = 0;
     db2 = 1;
@@ -71,17 +71,17 @@ unsigned char lpeek_debounced(long address)
 
 // cc65 and llvm have specialized assembler versions of lpeek and lpoke
 #if !defined(__clang__) && !defined(__CC65__)
-unsigned char lpeek(long address)
+unsigned char lpeek(uint32_t address)
 {
     return dma_peek(address);
 }
-void lpoke(long address, unsigned char value)
+void lpoke(uint32_t address, unsigned char value)
 {
     dma_poke(address, value);
 }
 #endif
 
-void dma_poke(long address, unsigned char value)
+void dma_poke(uint32_t address, unsigned char value)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -105,7 +105,8 @@ void dma_poke(long address, unsigned char value)
     return;
 }
 
-void lcopy(long source_address, long destination_address, unsigned int count)
+void lcopy(
+    uint32_t source_address, uint32_t destination_address, unsigned int count)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -137,7 +138,7 @@ void lcopy(long source_address, long destination_address, unsigned int count)
     return;
 }
 
-void lfill(long destination_address, unsigned char value, unsigned int count)
+void lfill(uint32_t destination_address, unsigned char value, unsigned int count)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
@@ -163,7 +164,7 @@ void lfill(long destination_address, unsigned char value, unsigned int count)
     return;
 }
 
-void lfill_skip(long destination_address, unsigned char value,
+void lfill_skip(uint32_t destination_address, unsigned char value,
     unsigned int count, unsigned char skip)
 {
     dmalist.option_0b = 0x0b;

--- a/src/random.c
+++ b/src/random.c
@@ -24,7 +24,7 @@ void generate_random_byte(void)
 
     while (random_step--) {
         random_byte
-            = (random_byte << 1) | (random_byte >> 7) ^ (PEEK(0xD6DE) & 0x01);
+            = (random_byte << 1) | ((random_byte >> 7) ^ (PEEK(0xD6DE) & 0x01));
         // We then have to wait 10usec before the next value is ready.
         // 1 raster line is more than that, so just wait one raster line
         raster_temp = PEEK(0xD052);

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -8,7 +8,7 @@
 
 uint8_t sector_buffer[512];
 
-const long sd_sectorbuffer = 0xffd6e00L;
+const uint32_t sd_sectorbuffer = 0xffd6e00U;
 const uint16_t sd_ctl = 0xd680L;
 const uint16_t sd_addr = 0xd681L;
 const uint16_t sd_errorcode = 0xd6daL;
@@ -17,7 +17,7 @@ unsigned char sdhc_card = 0;
 
 void mega65_clear_sector_buffer(void)
 {
-    lfill((int32_t)sector_buffer, 0, 512);
+    lfill((uint32_t)sector_buffer, 0, 512);
 }
 
 void mega65_sdcard_reset(void)
@@ -250,7 +250,7 @@ uint8_t mega65_sdcard_readsector(const uint32_t sector_number)
 
         if (!(PEEK(sd_ctl) & 0x67)) {
             // Copy data from hardware sector buffer via DMA
-            lcopy(sd_sectorbuffer, (long)sector_buffer, 512);
+            lcopy(sd_sectorbuffer, (uint32_t)sector_buffer, 512);
 
             return 0;
         }
@@ -303,7 +303,7 @@ uint8_t mega65_sdcard_writesector(const uint32_t sector_number)
     }
 
     // Copy the read data to a buffer for verification
-    lcopy(sd_sectorbuffer, (long)verify_buffer, 512);
+    lcopy(sd_sectorbuffer, (uint32_t)verify_buffer, 512);
 
     // VErify that it matches the data we wrote
     for (i = 0; i < 512; i++) {
@@ -318,7 +318,7 @@ uint8_t mega65_sdcard_writesector(const uint32_t sector_number)
     while (tries < 10) {
 
         // Copy data to hardware sector buffer via DMA
-        lcopy((long)sector_buffer, sd_sectorbuffer, 512);
+        lcopy((uint32_t)sector_buffer, sd_sectorbuffer, 512u);
 
         // Wait for SD card to be ready
         counter = 0;
@@ -392,7 +392,7 @@ uint8_t mega65_sdcard_writesector(const uint32_t sector_number)
             }
 
             // Copy the read data to a buffer for verification
-            lcopy(sd_sectorbuffer, (long)verify_buffer, 512);
+            lcopy(sd_sectorbuffer, (uint32_t)verify_buffer, 512);
 
             // VErify that it matches the data we wrote
             for (i = 0; i < 512; i++) {
@@ -426,8 +426,8 @@ void mega65_sdcard_erase(
     const uint32_t first_sector, const uint32_t last_sector)
 {
     uint32_t n;
-    lfill((int32_t)sector_buffer, 0, 512);
-    lcopy((long)sector_buffer, sd_sectorbuffer, 512);
+    lfill((uint32_t)sector_buffer, 0, 512);
+    lcopy((uint32_t)sector_buffer, sd_sectorbuffer, 512);
 
     //  fprintf(stderr,"ERASING SECTORS %d..%d\r\n",first_sector,last_sector);
 

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -8,10 +8,10 @@
 
 uint8_t sector_buffer[512];
 
-const uint32_t sd_sectorbuffer = 0xffd6e00U;
-const uint16_t sd_ctl = 0xd680L;
-const uint16_t sd_addr = 0xd681L;
-const uint16_t sd_errorcode = 0xd6daL;
+const uint32_t sd_sectorbuffer = 0xffd6e00UL;
+const uint16_t sd_ctl = 0xd680U;
+const uint16_t sd_addr = 0xd681U;
+const uint16_t sd_errorcode = 0xd6daU;
 
 unsigned char sdhc_card = 0;
 
@@ -62,12 +62,12 @@ uint32_t mega65_sdcard_getsize(void)
     mega65_sdcard_reset();
 
     // Begin with aligned address, and confirm it works ok.
-    POKE(0xD681U, 0);
-    POKE(0xD682U, 0);
-    POKE(0xD683U, 0);
-    POKE(0xD684U, 0);
+    POKE(0xD681, 0);
+    POKE(0xD682, 0);
+    POKE(0xD683, 0);
+    POKE(0xD684, 0);
     // Trigger read
-    POKE(0xD680U, 2);
+    POKE(0xD680, 2);
 
     // Allow a lot of time for first read after reset to complete
     // (some cards take a while)
@@ -79,12 +79,12 @@ uint32_t mega65_sdcard_getsize(void)
     }
 
     // Setup non-aligned address
-    POKE(0xD681U, 2);
-    POKE(0xD682U, 0);
-    POKE(0xD683U, 0);
-    POKE(0xD684U, 0);
+    POKE(0xD681, 2);
+    POKE(0xD682, 0);
+    POKE(0xD683, 0);
+    POKE(0xD684, 0);
     // Trigger read
-    POKE(0xD680U, 2);
+    POKE(0xD680, 2);
     // Then sleep for plenty of time for the read to complete
     for (result = 0; result < 20; result++) {
         if (PEEK(sd_ctl & 3) == 0) {
@@ -99,7 +99,7 @@ uint32_t mega65_sdcard_getsize(void)
     }
     else {
         //    write_line("SDSC (<4GB) card detected. Using byte addressing.",0);
-        POKE(0xD680U, 0x40);
+        POKE(0xD680, 0x40);
         mega65_sdcard_reset();
         sdhc_card = 0;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,3 +12,4 @@ function(TEST NAME)
 endfunction()
 
 TEST(test-memory)
+TEST(test-integer-size)

--- a/tests/test-integer-size.c
+++ b/tests/test-integer-size.c
@@ -1,0 +1,47 @@
+/**
+ * Tests for integer sizes
+ *
+ * This can be run in Xemu in testing mode with e.g.
+ *
+ *     xmega65 -testing -headless -sleepless -prg test-integer-size.prg
+ *
+ * If a test fails, xemu will exit with a non-zero return code.
+ */
+#include <mega65/memory.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define XEMU_CONTROL 0xD6CF
+#define XEMU_QUIT 0x42
+
+void xemu_exit(int exit_code)
+{
+    POKE(XEMU_CONTROL, (uint8_t)exit_code);
+    POKE(XEMU_CONTROL, XEMU_QUIT);
+    exit(exit_code);
+}
+
+#define assert_eq(A, B)                                                        \
+    if (A != B)                                                                \
+    xemu_exit(EXIT_FAILURE)
+
+int main(void)
+{
+    // Integer sizes
+    assert_eq(sizeof(uint8_t), 1);
+    assert_eq(sizeof(unsigned char), 1);
+    assert_eq(UINT8_MAX, 0xFF);
+
+    assert_eq(sizeof(uint16_t), 2);
+    assert_eq(sizeof(unsigned int), 2);
+    assert_eq(UINT16_MAX, 0xFFFF);
+
+    assert_eq(sizeof(uint32_t), 4);
+    assert_eq(sizeof(unsigned long), 4);
+    assert_eq(UINT32_MAX, 0xFFFFFFFF);
+
+    assert_eq(INT16_MAX, 0x7FFF);
+    assert_eq(INT32_MAX, 0x7FFFFFFF);
+    xemu_exit(EXIT_SUCCESS);
+}
+

--- a/tests/test-integer-size.c
+++ b/tests/test-integer-size.c
@@ -34,6 +34,8 @@ int main(void)
 
     assert_eq(sizeof(uint16_t), 2);
     assert_eq(sizeof(unsigned int), 2);
+    assert_eq(sizeof(unsigned short), 2);
+    assert_eq(sizeof(size_t), 2);
     assert_eq(UINT16_MAX, 0xFFFF);
 
     assert_eq(sizeof(uint32_t), 4);
@@ -44,4 +46,3 @@ int main(void)
     assert_eq(INT32_MAX, 0x7FFFFFFF);
     xemu_exit(EXIT_SUCCESS);
 }
-

--- a/tests/test-memory.c
+++ b/tests/test-memory.c
@@ -27,22 +27,6 @@ void xemu_exit(int exit_code)
 
 int main(void)
 {
-    // Integer sizes
-    assert_eq(sizeof(uint8_t), 1);
-    assert_eq(sizeof(unsigned char), 1);
-    assert_eq(UINT8_MAX, 0xFF);
-
-    assert_eq(sizeof(uint16_t), 2);
-    assert_eq(sizeof(unsigned int), 2);
-    assert_eq(UINT16_MAX, 0xFFFF);
-
-    assert_eq(sizeof(uint32_t), 4);
-    assert_eq(sizeof(unsigned long), 4);
-    assert_eq(UINT32_MAX, 0xFFFFFFFF);
-
-    assert_eq(INT16_MAX, 0x7FFF);
-    assert_eq(INT32_MAX, 0x7FFFFFFF);
-
     // PEEK and POKE macros
     POKE(0x3000, 7);
     POKE(0x3001, 9);

--- a/tests/test-memory.c
+++ b/tests/test-memory.c
@@ -27,6 +27,22 @@ void xemu_exit(int exit_code)
 
 int main(void)
 {
+    // Integer sizes
+    assert_eq(sizeof(uint8_t), 1);
+    assert_eq(sizeof(unsigned char), 1);
+    assert_eq(UINT8_MAX, 0xFF);
+
+    assert_eq(sizeof(uint16_t), 2);
+    assert_eq(sizeof(unsigned int), 2);
+    assert_eq(UINT16_MAX, 0xFFFF);
+
+    assert_eq(sizeof(uint32_t), 4);
+    assert_eq(sizeof(unsigned long), 4);
+    assert_eq(UINT32_MAX, 0xFFFFFFFF);
+
+    assert_eq(INT16_MAX, 0x7FFF);
+    assert_eq(INT32_MAX, 0x7FFFFFFF);
+
     // PEEK and POKE macros
     POKE(0x3000, 7);
     POKE(0x3001, 9);

--- a/tests/test-memory.c
+++ b/tests/test-memory.c
@@ -7,9 +7,8 @@
  *
  * If a test fails, xemu will exit with a non-zero return code.
  */
-#include <stdlib.h>
-#include <stdio.h>
 #include <mega65/memory.h>
+#include <stdlib.h>
 
 #define XEMU_CONTROL 0xD6CF
 #define XEMU_QUIT 0x42
@@ -27,6 +26,9 @@ void xemu_exit(int exit_code)
 
 int main(void)
 {
+    // DMAGIC DMA list size
+    assert_eq(sizeof(struct dmagic_dmalist), 20);
+
     // PEEK and POKE macros
     POKE(0x3000, 7);
     POKE(0x3001, 9);

--- a/tests/test-memory.c
+++ b/tests/test-memory.c
@@ -52,12 +52,12 @@ int main(void)
     assert_eq(lpeek(0x4002), 7);
 
     // dma_poke and dma_peek
-    dma_poke(0x4000, 13);
-    dma_poke(0x4001, 9);
-    dma_poke(0x4002, 7);
-    assert_eq(dma_peek(0x4000), 13);
-    assert_eq(dma_peek(0x4001), 9);
-    assert_eq(dma_peek(0x4002), 7);
+    dma_poke(0x4000, 9);
+    dma_poke(0x4001, 10);
+    dma_poke(0x4002, 11);
+    assert_eq(dma_peek(0x4000), 9);
+    assert_eq(dma_peek(0x4001), 10);
+    assert_eq(dma_peek(0x4002), 11);
 
     // lfill
     lfill(0x3000, 1, 3);


### PR DESCRIPTION
This add the following changes to ongoing work on reducing the number of warnings emitted by clang:
- [x] Explicitly named stdint integers, e.g. `uint16_t` over `unsigned int` in `memory.h`
- [x] Memory 28-bit addresses changed from signed `long` to unsigned `uint32_t` in `memory.h`
- [x] Explicitly pack structs on clang (for llvm-mos-sdk version v2.0.0 or earlier, see fix in https://github.com/llvm-mos/llvm-mos/commit/09aa314634ec1a3b9c56fdf8f19fc8bd71fa547d)
- [x] Add test-integer test target
- [x] Slightly stronger test of `dma_poke()` and `dma_peek()`
- [x] Removed redundant includes on cc65
- [x] Return named error instead of -1 in sdcard (see #37).
- [x] Partial replacement of implicit casts with explicit ones

Closes #37.