### PR TITLE
Add tests to cc65 build as well as fileio test

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Build using cc65
       working-directory: ${{github.workspace}}
-      run: USE_LOCAL_CC65=1 make -f Makefile_cc65
+      run: USE_LOCAL_CC65=1 make -f Makefile_cc65 all
     
     - name: Install llvm-mos-sdk
       working-directory: ${{github.workspace}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# PRG files
+*.prg
+tests/*.prg
+
 # Prerequisites
 *.d
 

--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -73,7 +73,7 @@ test: | $(TESTS_PRGS)
 	    echo "Cannot run tests as xmega65 (Xemu) is not in your path."; \
 	else \
 	    for test in $(TESTS_PRGS); do \
-	        if $(XEMU) -testing -sleepless -headless -8 MEGADEMO.d81 -prg $$test &> /dev/null; then \
+	        if $(XEMU) -testing -sleepless -headless -prg $$test &> /dev/null; then \
                     echo "Test passed: $$test"; \
 	        else \
 	            echo "Test FAILED: $$test"; \

--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -39,7 +39,7 @@ LIB_OBJECTS = \
 
 .PHONY: all clean cleanall test
 
-all: libmega65.a
+all: libmega65.a ${TESTS_PRGS}
 
 libmega65.a: $(LIB_OBJECTS)
 	$(AR65) a $@ $^

--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -73,7 +73,7 @@ test: | $(TESTS_PRGS)
 	    echo "Cannot run tests as xmega65 (Xemu) is not in your path."; \
 	else \
 	    for test in $(TESTS_PRGS); do \
-	        if $(XEMU) -testing -sleepless -headless -prg $$test &> /dev/null; then \
+	        if $(XEMU) -testing -sleepless -headless -model 3 -prg $$test &> /dev/null; then \
                     echo "Test passed: $$test"; \
 	        else \
 	            echo "Test FAILED: $$test"; \

--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -1,5 +1,9 @@
 
 SHELL:=/bin/bash
+XEMU=xmega65
+TESTS_DIR := tests
+TESTS_SRCS := $(wildcard $(TESTS_DIR)/*.c)
+TESTS_PRGS := $(TESTS_SRCS:.c=.prg)
 
 ifdef USE_LOCAL_CC65
     # use locally installed binary (requires 'cc65,ld65,etc' to be in the $PATH)
@@ -10,10 +14,11 @@ else
 endif
 
 CC65=$(CC65_PREFIX)cc65
+CL65=$(CC65_PREFIX)cl65
 CA65=$(CC65_PREFIX)ca65 --cpu 4510
 AR65=$(CC65_PREFIX)ar65
 
-CFLAGS=-O -t c64 -W +unused-param,+error,+unused-label,+no-effect,+unused-var,+no-effect -I include/
+CFLAGS=-O -t c64 -I include/
 
 LIB_OBJECTS = \
 	src/cc65/dirent.o \
@@ -32,20 +37,19 @@ LIB_OBJECTS = \
 	src/tests.o \
 	src/time.o
 
-.PHONY: all clean cleanall
+.PHONY: all clean cleanall test
 
-all: libmega65.a
+libmega65.a: $(LIB_OBJECTS)
+	$(AR65) a $@ $^
+
+all: libmega65.a $(TESTS_PRGS)
 
 clean:
-	rm -f src/*.o
-	rm -f src/cc65/*.o
+	rm -f $(LIB_OBJECTS) $(TESTS_PRGS) tests/*.o
 	rm -rf work
 
 cleanall: clean
 	rm -f libmega65.a
-
-libmega65.a: $(LIB_OBJECTS)
-	$(AR65) a $@ $^
 
 src/cc65/%.o: src/cc65/%.s
 	$(CA65) -o $@ $<
@@ -56,3 +60,24 @@ src/%.o: src/%.c
 	fi
 	$(CC65) $(CFLAGS) -o work/$*.s $<
 	$(CA65) -o $@ work/$*.s
+
+# Unit tests using Xemu in "testing" mode
+#
+# - Xemu `xmega65` must be in your path
+# - Xemu's return code is controlled by register 0xD6CF
+# - All tests are in the `tests/` directory
+tests/%.prg: tests/%.c libmega65.a
+	$(CL65) $(CFLAGS) $< -o $@ libmega65.a
+test: | $(TESTS_PRGS)
+	@if ! command -v $(XEMU) &> /dev/null; then \
+	    echo "Cannot run tests as xmega65 (Xemu) is not in your path."; \
+	else \
+	    for test in $(TESTS_PRGS); do \
+	        if $(XEMU) -testing -sleepless -headless -8 MEGADEMO.d81 -prg $$test &> /dev/null; then \
+                    echo "Test passed: $$test"; \
+	        else \
+	            echo "Test FAILED: $$test"; \
+	        fi; \
+	    done; \
+        fi
+

--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -39,10 +39,10 @@ LIB_OBJECTS = \
 
 .PHONY: all clean cleanall test
 
+all: libmega65.a
+
 libmega65.a: $(LIB_OBJECTS)
 	$(AR65) a $@ $^
-
-all: libmega65.a $(TESTS_PRGS)
 
 clean:
 	rm -f $(LIB_OBJECTS) $(TESTS_PRGS) tests/*.o

--- a/README.md
+++ b/README.md
@@ -18,17 +18,23 @@ Simple C library for the MEGA65
 ## Clang
 
 1. Install [llvm-mos-sdk](https://github.com/llvm-mos/llvm-mos-sdk#getting-started).
+This e.g. downloads for linux and unpacks into `$HOME/llvm-mos`:
+~~~ sh
+wget https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz 
+tar xf llvm-mos-linux.tar.xz -C $HOME
+~~~
 2. Configure and make with:
 ~~~ sh
-cmake -DCMAKE_PREFIX_PATH=<llvm-mos-sdk-install-prefix> -B build/ mega65-libc/
-cd build/
+cmake -DCMAKE_PREFIX_PATH=$HOME/llvm-mos -B build/ mega65-libc/
+cd build
 make
-make test # if `xmega65` (Xemu) is in your path
+make test # if `xmega65` (Xemu) was in your patch when running cmake
 ~~~
 
-### Dependent CMake projects
+### Dependent projects
 
-`CMakeLists.txt` of a dependent project could look like this:
+It's trivial to write a classic `Makefile` for clang.
+For dependent CMake based projects, `CMakeLists.txt` could look like this:
 ~~~ cmake
 cmake_minimum_required(VERSION 3.5)
 set(LLVM_MOS_PLATFORM mega65)

--- a/include/mega65/debug.h
+++ b/include/mega65/debug.h
@@ -1,6 +1,10 @@
 #ifndef __MEGA65_DEBUG_H
 #define __MEGA65_DEBUG_H
 
-void debug_msg(char* m);
+/**
+ * @brief Write debug message to serial monitor
+ * @param msg Text message to write
+ */
+void debug_msg(char* msg);
 
 #endif // __MEGA65_DEBUG_H

--- a/include/mega65/dirent.h
+++ b/include/mega65/dirent.h
@@ -3,20 +3,26 @@
 
 #include <stdint.h>
 
+/// Open a directory
 unsigned char opendir(void);
+
+/// Read directory entry
 struct m65_dirent* readdir(unsigned char);
+
+/// Close directory entry
 void closedir(unsigned char);
 
+/// Structure describing an open directory
 #ifdef __clang__
 struct __attribute__((__packed__)) m65_dirent {
 #else
 struct m65_dirent {
 #endif
-    uint32_t d_ino;
-    uint16_t d_off;
-    uint32_t d_reclen;
-    uint16_t d_type;
-    char d_name[256];
+    uint32_t d_ino;    //!< File number of entry
+    uint16_t d_off;    //!< Offset
+    uint32_t d_reclen; //!< Length of this record
+    uint16_t d_type;   //!< File type
+    char d_name[256];  //!< Filename string of entry
 };
 
 #endif // __MEGA65_DIRENT_H

--- a/include/mega65/fcio.h
+++ b/include/mega65/fcio.h
@@ -1,9 +1,7 @@
-
-/*! @file fcio.h
-    @brief Full colour mode i/o library for the MEGA65
-
-    Details.
-*/
+/**
+ * @file fcio.h
+ * @brief Full colour mode i/o library for the MEGA65
+ */
 
 #ifndef __MEGA65_FCIO_H
 #define __MEGA65_FCIO_H

--- a/include/mega65/fileio.h
+++ b/include/mega65/fileio.h
@@ -1,22 +1,46 @@
 #ifndef __MEGA65_FILEIO_H
 #define __MEGA65_FILEIO_H
 
-void toggle_rom_write_protect();
+#include <stdint.h>
+#include <stddef.h>
+
+void toggle_rom_write_protect(void);
+
+/** Closes all open files */
 void closeall(void);
-void close(unsigned char fd);
 
-// Returns file descriptor
-unsigned char open(char* filename);
+/**
+ * @brief Close a single file
+ * @param fd File descriptor pointing to file to close
+ */
+void close(uint8_t fd);
 
-// Read upto one sector of data into the supplied buffer.
-// Returns the number of bytes actually read.
-unsigned short read512(unsigned char* buffer);
+/**
+ * @brief Open file
+ * @param filename to open
+ * @return File descriptor or `0xff` if error
+ */
+uint8_t open(char* filename);
 
-// Change working directory
-// (only accepts one directory segment at a time
-unsigned char chdir(char* filename);
+/**
+ * @brief Read up to 512 bytes from file
+ * @param buffer Input buffer
+ * @return Number of bytes read
+ */
+size_t read512(uint8_t* buffer);
 
-// Change working directory to the root directory
-unsigned char chdirroot(void);
+/**
+ * @brief Change working directory
+ * @param filename Directory name
+ * @return Error code (currently unused)
+ * @note Only accepts one directory segment at a time
+ */
+uint8_t chdir(char* filename);
+
+/**
+ * @brief Change working directory to the root directory
+ * @return Error code (currently unused)
+ */
+uint8_t chdirroot(void);
 
 #endif // __MEGA65_FILEIO_H

--- a/include/mega65/hal.h
+++ b/include/mega65/hal.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+/**
+ * @brief Sleep for the given number of microseconds
+ * @param micros Microseconds to sleep
+ */
 void usleep(uint32_t micros);
 
 #endif // __MEGA65_HAL_H

--- a/include/mega65/memory.h
+++ b/include/mega65/memory.h
@@ -2,7 +2,14 @@
 #define __MEGA65_MEMORY_H
 
 #include <stdint.h>
+#include <stddef.h>
 
+#define DMA_COPY_CMD 0x00;
+#define DMA_FILL_CMD 0x03;
+
+/**
+ * @brief DMA list structure
+ */
 #ifdef __clang__
 struct __attribute__((__packed__)) dmagic_dmalist {
 #else
@@ -37,17 +44,65 @@ extern struct dmagic_dmalist dmalist;
 extern uint8_t dma_byte;
 #endif
 
+/**
+ * @brief Enable Mega65 mode
+ */
 void mega65_io_enable(void);
+
+/**
+ * @brief Peek a byte from the given address
+ * @param address 28-bit address
+ * @return uint8_t with the value at the given address
+ */
 uint8_t lpeek(uint32_t address);
 uint8_t lpeek_debounced(uint32_t address);
+
+/**
+ * @brief Peek a byte from the given address using DMA copy
+ * @param address 28-bit address
+ * @return Single byte from the given address
+ */
 uint8_t dma_peek(uint32_t address);
+
+/**
+ * @brief Poke a byte to the given address
+ * @param address 28-bit address
+ * @param value Single byte to write to the given address
+ */
 void lpoke(uint32_t address, uint8_t value);
+
+/**
+ * @brief Poke a byte to the given address using DMA copy
+ * @param address 28-bit address
+ * @param value Single byte to write to the given address
+ */
 void dma_poke(uint32_t address, uint8_t value);
-void lcopy(
-    uint32_t source_address, uint32_t destination_address, uint16_t count);
-void lfill(uint32_t destination_address, uint8_t value, uint16_t count);
+
+/**
+ * @brief Copy a block of memory using DMA
+ * @param source_address 28-bit address to copy from
+ * @param destination_address 28-bit address to copy to
+ * @param count Number of bytes to copy
+ */
+void lcopy(uint32_t source_address, uint32_t destination_address, size_t count);
+
+/**
+ * @brief Fill a block of memory with a single byte using DMA
+ * @param destination_address Start address (28-bit)
+ * @param value Fill value
+ * @param count Number of bytes to fill
+ */
+void lfill(uint32_t destination_address, uint8_t value, size_t count);
+
+/**
+ * @brief Fill a block of memory with a single byte using DMA with a step
+ * @param destination_address Start address (28-bit)
+ * @param value Fill value
+ * @param count Number of bytes to fill
+ * @param skip Skip every n bytes
+ */
 void lfill_skip(
-    uint32_t destination_address, uint8_t value, uint16_t count, uint8_t skip);
+    uint32_t destination_address, uint8_t value, size_t count, uint8_t skip);
 
 #ifdef __clang__
 #define POKE(X, Y) (*(volatile uint8_t*)(X)) = Y

--- a/include/mega65/targets.h
+++ b/include/mega65/targets.h
@@ -1,6 +1,8 @@
 #ifndef __MEGA65_TARGETS_H
 #define __MEGA65_TARGETS_H
 
+#include <stdint.h>
+
 #define TARGET_UNKNOWN 0
 #define TARGET_MEGA65R1 1
 #define TARGET_MEGA65R2 2
@@ -12,7 +14,9 @@
 #define TARGET_NEXYS4DDRWIDGET 0x42
 #define TARGET_WUKONG 0xFD
 #define TARGET_SIMULATION 0xFE
+#define TARGET_EMULATION 0xFF //!< Emulator like Xemu
 
-unsigned char detect_target(void);
+/// Detects the target on which we're running
+uint8_t detect_target(void);
 
 #endif // __MEGA65_TARGETS_H

--- a/include/mega65/tests.h
+++ b/include/mega65/tests.h
@@ -17,7 +17,9 @@
 /**
  * @brief Quits Xemu with given exit code
  * @param exit_code Exit code passed to Xemu, e.g. EXIT_SUCCESS or EXIT_FAILURE
- * @note Xemu must be run in `-testing` mode for this to have any effect
+ *
+ * Xemu must be run in `-testing` mode for this to have any effect and
+ * also make sure to call `mega65_io_enable()` before calling this function.
  */
 void xemu_exit(int exit_code);
 

--- a/include/mega65/tests.h
+++ b/include/mega65/tests.h
@@ -11,6 +11,15 @@
 #define TEST_LOG 0xfd
 #define TEST_SETNAME 0xfe
 #define TEST_DONEALL 0xff
+#define XEMU_CONTROL 0xD6CF
+#define XEMU_QUIT 0x42
+
+/**
+ * @brief Quits Xemu with given exit code
+ * @param exit_code Exit code passed to Xemu, e.g. EXIT_SUCCESS or EXIT_FAILURE
+ * @note Xemu must be run in `-testing` mode for this to have any effect
+ */
+void xemu_exit(int exit_code);
 
 // convenience methods
 

--- a/include/mega65/time.h
+++ b/include/mega65/time.h
@@ -25,7 +25,9 @@ struct m65_tm {
     unsigned char tm_isdst; /* Daylight saving time */
 };
 
+/// Get real-time clock
 void getrtc(struct m65_tm* tm);
+/// Set real-time clock
 void setrtc(struct m65_tm* tm);
 
 #endif // __MEGA65_TIME_H

--- a/src/cc65/fileio.s
+++ b/src/cc65/fileio.s
@@ -15,29 +15,6 @@ mega65_io_enable:
 	sta $d02f
 	rts
 	
-cc65_args_read_ptr1_16:	
-        ;; sp here is the ca65 sp ZP variable, not the stack pointer of a 4510
-        .p02
-	
-        lda (sp),y
-        sta ptr1
-        iny
-        lda (sp),y
-        .p4510
-        sta ptr1+1
-	iny
-	rts
-        
-cc65_args_read_tmp1_8:	
-        ;; sp here is the ca65 sp ZP variable, not the stack pointer of a 4510
-        .p02
-        lda (sp),y
-        sta tmp1
-        iny
-        .p4510
-	rts
-        
-
 cc65_copy_ptr1_string_to_0100:	
         ;; Copy file name
 	phy

--- a/src/debug.c
+++ b/src/debug.c
@@ -9,13 +9,13 @@ void debug_msg(char* msg)
         __asm__("LDA %v", the_char);
         __asm__("STA $D643");
         __asm__("NOP");
-        m++;
 #else
         asm volatile("lda the_char\n"
                      "sta $d643\n"
                      "nop" ::
                          : "a");
 #endif
+        msg++;
     }
 #ifdef __CC65__
     __asm__("LDA #$0d");

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,11 +1,10 @@
 #include <mega65/memory.h>
 
 unsigned char the_char;
-void debug_msg(char* m)
+void debug_msg(char* msg)
 {
-    // Write debug message to serial monitor
-    while (*m) {
-        the_char = *m;
+    while (*msg) {
+        the_char = *msg;
 #ifdef __CC65__
         __asm__("LDA %v", the_char);
         __asm__("STA $D643");

--- a/src/llvm/fileio.s
+++ b/src/llvm/fileio.s
@@ -1,18 +1,14 @@
     .global closeall, open, close, read512, toggle_rom_write_protect, chdir, chdirroot
 
     ;; allocate space in zeropage
-    .section .zeropage,"",@nobits
+    .section .zeropage,"aw",@nobits
 ptr1:
         .ds.b 1 ;; 1 byte
 ptr2:
         .ds.b 1
-tmp1:
-        .ds.b 1
 tmp2:
         .ds.b 1
 tmp3:
-        .ds.b 1
-sp:
         .ds.b 1
 
     .section code,"a"
@@ -22,23 +18,6 @@ mega65_io_enable:
 	sta $d02f
 	lda #$53
 	sta $d02f
-	rts
-cc65_args_read_ptr1_16:	
-        ;; sp here is the ca65 sp ZP variable, not the stack pointer of a 4510
-	
-        lda (sp),y
-        sta ptr1
-        iny
-        lda (sp),y
-        sta ptr1+1
-	iny
-	rts
-        
-cc65_args_read_tmp1_8:	
-        ;; sp here is the ca65 sp ZP variable, not the stack pointer of a 4510
-        lda (sp),y
-        sta tmp1
-        iny
 	rts
         
 cc65_copy_ptr1_string_to_0100:	
@@ -75,7 +54,8 @@ closeall:
 	LDA #$22
 	STA $D640
 	NOP
-	LDX #$00
+	;Not needed on llvm-mos
+	;LDX #$00
 	RTS
 
 toggle_rom_write_protect:
@@ -83,11 +63,13 @@ toggle_rom_write_protect:
 	lda #$70
 	STA $d640
 	nop
-	ldx #0
+	;ldx #0
 	rts
 	
 read512:
 	;;  Get pointer to buffer
+	lda __rc2
+	ldx __rc3
 	sta ptr1+0
 	stx ptr1+1
 
@@ -99,7 +81,7 @@ read512:
 	LDA #$1A
 	STA $D640
 	NOP
-	LDX #$00
+	;LDX #$00
 
 	;; Number of bytes read returned in X and Y
 	;; Store these for returning
@@ -153,9 +135,13 @@ copysectorbuffer_destaddr:
         .short $8000 ;; destination address is $8000
         .byte $00   ;; of bank $0
         .short $0000 ;; modulo (unused)
-	
+
+    .section code,"a"
+
 open:
-        ;; Get pointer to file name
+    ; argument pointer stored in rc2 and rc3
+	lda __rc2
+	ldx __rc3
 	sta ptr1+0
 	stx ptr1+1
 	
@@ -184,8 +170,9 @@ open_file_exists:
 	LDA #$18
 	STA $D640
 	NOP
-	
-	LDX #$00
+
+	;clearing X not needed on llvm-mos	
+	;LDX #$00
 	RTS
 
 close:
@@ -194,7 +181,7 @@ close:
 	LDA #$20
 	STA $D640
 	NOP
-	LDX #$00
+	;LDX #$00
 	RTS
 
 chdirroot:
@@ -204,11 +191,13 @@ chdirroot:
 	sta $d640
 	nop
 
-	ldx #$00
+	;ldx #$00
 	rts
 	
 chdir:
         ;; Get pointer to file name
+	lda __rc2
+	ldx __rc3
 	sta ptr1+0
 	stx ptr1+1
 	
@@ -238,5 +227,6 @@ chdir_file_exists:
 	STA $D640
 	NOP
 	
-	LDX #$00
+	;; Not needed on llvm-mos
+	;;LDX #$00
 	RTS

--- a/src/llvm/fileio.s
+++ b/src/llvm/fileio.s
@@ -3,13 +3,7 @@
     ;; allocate space in zeropage
     .section .zeropage,"aw",@nobits
 ptr1:
-        .ds.b 1 ;; 1 byte
-ptr2:
-        .ds.b 1
-tmp2:
-        .ds.b 1
-tmp3:
-        .ds.b 1
+        .ds.b 2
 
     .section code,"a"
 
@@ -85,8 +79,8 @@ read512:
 
 	;; Number of bytes read returned in X and Y
 	;; Store these for returning
-	stx tmp2
-	sty tmp3
+	stx __rc2
+	sty __rc3
 
 	;; Make sure SD buffer is selected, not FDC buffer
 	lda #$80
@@ -112,8 +106,8 @@ read512:
 	sta $d705
 
 	;; Retrieve the return value
-	lda tmp2
-	ldx tmp3
+	lda __rc2
+	ldx __rc3
 	RTS	
 
 	.data

--- a/src/memory.c
+++ b/src/memory.c
@@ -35,7 +35,7 @@ uint8_t dma_peek(uint32_t address)
 
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
-    dmalist.source_mb = (address >> 20);
+    dmalist.source_mb = (uint8_t)(address >> 20);
     dmalist.option_81 = 0x81;
     dmalist.dest_mb = 0x00; // dma_byte lives in 1st MB
     dmalist.option_85 = 0x85;
@@ -87,7 +87,7 @@ void dma_poke(uint32_t address, uint8_t value)
     dmalist.option_80 = 0x80;
     dmalist.source_mb = 0x00; // dma_byte lives in 1st MB
     dmalist.option_81 = 0x81;
-    dmalist.dest_mb = (address >> 20);
+    dmalist.dest_mb = (uint8_t)(address >> 20);
     dmalist.option_85 = 0x85;
     dmalist.dest_skip = 1;
     dmalist.end_of_options = 0x00;
@@ -110,9 +110,9 @@ void lcopy(
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
-    dmalist.source_mb = source_address >> 20;
+    dmalist.source_mb = (uint8_t)(source_address >> 20);
     dmalist.option_81 = 0x81;
-    dmalist.dest_mb = (destination_address >> 20);
+    dmalist.dest_mb = (uint8_t)(destination_address >> 20);
     dmalist.option_85 = 0x85;
     dmalist.dest_skip = 1;
     dmalist.end_of_options = 0x00;
@@ -144,7 +144,7 @@ void lfill(uint32_t destination_address, uint8_t value, uint16_t count)
     dmalist.option_80 = 0x80;
     dmalist.source_mb = 0x00;
     dmalist.option_81 = 0x81;
-    dmalist.dest_mb = destination_address >> 20;
+    dmalist.dest_mb = (uint8_t)(destination_address >> 20);
     dmalist.option_85 = 0x85;
     dmalist.dest_skip = 1;
     dmalist.end_of_options = 0x00;
@@ -164,14 +164,14 @@ void lfill(uint32_t destination_address, uint8_t value, uint16_t count)
     return;
 }
 
-void lfill_skip(uint32_t destination_address, uint8_t value, uint16_t count,
-    uint8_t skip)
+void lfill_skip(
+    uint32_t destination_address, uint8_t value, uint16_t count, uint8_t skip)
 {
     dmalist.option_0b = 0x0b;
     dmalist.option_80 = 0x80;
     dmalist.source_mb = 0x00;
     dmalist.option_81 = 0x81;
-    dmalist.dest_mb = destination_address >> 20;
+    dmalist.dest_mb = (uint8_t)(destination_address >> 20);
     dmalist.option_85 = 0x85;
     dmalist.dest_skip = skip;
     dmalist.end_of_options = 0x00;

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,5 +1,4 @@
 #include <mega65/memory.h>
-#include <stdio.h>
 
 #ifdef __clang__
 volatile struct dmagic_dmalist dmalist;
@@ -43,7 +42,7 @@ uint8_t dma_peek(uint32_t address)
     dmalist.end_of_options = 0x00;
     dmalist.sub_cmd = 0x00;
 
-    dmalist.command = 0x00; // copy
+    dmalist.command = DMA_COPY_CMD;
     dmalist.count = 1;
     dmalist.source_addr = address & 0xffff;
     dmalist.source_bank = (address >> 16) & 0x0f;
@@ -94,7 +93,7 @@ void dma_poke(uint32_t address, uint8_t value)
     dmalist.sub_cmd = 0x00;
 
     dma_byte = value;
-    dmalist.command = 0x00; // copy
+    dmalist.command = DMA_COPY_CMD;
     dmalist.count = 1;
     dmalist.source_addr = (uint16_t)&dma_byte;
     dmalist.source_bank = 0;
@@ -118,7 +117,7 @@ void lcopy(
     dmalist.end_of_options = 0x00;
     dmalist.sub_cmd = 0x00;
 
-    dmalist.command = 0x00; // copy
+    dmalist.command = DMA_COPY_CMD;
     dmalist.count = count;
     dmalist.sub_cmd = 0;
     dmalist.source_addr = source_address & 0xffff;
@@ -149,7 +148,7 @@ void lfill(uint32_t destination_address, uint8_t value, uint16_t count)
     dmalist.dest_skip = 1;
     dmalist.end_of_options = 0x00;
 
-    dmalist.command = 0x03; // fill
+    dmalist.command = DMA_FILL_CMD;
     dmalist.sub_cmd = 0;
     dmalist.count = count;
     dmalist.source_addr = value;
@@ -176,7 +175,7 @@ void lfill_skip(
     dmalist.dest_skip = skip;
     dmalist.end_of_options = 0x00;
 
-    dmalist.command = 0x03; // fill
+    dmalist.command = DMA_FILL_CMD;
     dmalist.sub_cmd = 0;
     dmalist.count = count;
     dmalist.source_addr = value;

--- a/src/targets.c
+++ b/src/targets.c
@@ -1,13 +1,9 @@
-#include <stdio.h>
 #include <mega65/memory.h>
 #include <mega65/targets.h>
 
-unsigned char detect_target(void)
+uint8_t detect_target(void)
 {
     // We use the different I2C device blocks to identify the various hardware
     // targets
-
     return lpeek(0xffd3629);
-
-    return TARGET_UNKNOWN;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -3,10 +3,18 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 unsigned char __tests_out;
 unsigned short __ut_issueNum;
 unsigned char __ut_subissue;
+
+void xemu_exit(int exit_code)
+{
+    POKE(XEMU_CONTROL, (uint8_t)exit_code);
+    POKE(XEMU_CONTROL, XEMU_QUIT);
+    exit(exit_code);
+}
 
 void unit_test_report(
     unsigned short issue, unsigned char sub, unsigned char status)

--- a/src/time.c
+++ b/src/time.c
@@ -1,3 +1,4 @@
+
 /*
   The MEGA65 really only has a Real-Time Clock (RTC), so we just have handy
   functions for that.
@@ -10,7 +11,6 @@
 #include <mega65/time.h>
 #include <mega65/targets.h>
 #include <mega65/hal.h>
-#include <stdio.h>
 
 #define I2CDELAY 5000L
 
@@ -59,6 +59,7 @@ void getrtc(struct m65_tm* tm)
     tm->tm_isdst = 0;
 
     switch (detect_target()) {
+    case TARGET_EMULATION:
     case TARGET_MEGA65R2:
     case TARGET_MEGA65R3:
         tm->tm_sec = unbcd(lpeek_debounced(0xffd7110));
@@ -129,7 +130,7 @@ void setrtc(struct m65_tm* tm)
         lpoke(0xffd7114, tobcd(tm->tm_mon));
         if (tm->tm_year >= 100 && tm->tm_year <= 355) {
             usleep(I2CDELAY);
-            lpoke(0xffd7115, tobcd(tm->tm_year - 100));
+            lpoke(0xffd7115, tobcd((uint8_t)(tm->tm_year - 100)));
         }
         usleep(I2CDELAY);
         lpoke(0xffd7116, tobcd(tm->tm_wday));

--- a/src/time.c
+++ b/src/time.c
@@ -14,14 +14,17 @@
 
 #define I2CDELAY 5000L
 
-unsigned char bcd_work;
+uint8_t bcd_work;
 
-/*
-  While the double dabble algorithm is more time efficient, we mostly care about
-  saving space, so use a simple loop.  Getting/setting time should not be called
-  particularly often.
+/**
+ * @brief Convert a binary value to binary coded decimal (BCD)
+ * @return uint8_t BCD value
+ *
+ * While the double dabble algorithm is more time efficient, we mostly care
+ * about saving space, so use a simple loop.  Getting/setting time should not be
+ * called particularly often.
  */
-unsigned char tobcd(unsigned char in)
+uint8_t tobcd(uint8_t in)
 {
     bcd_work = 0;
     while (in > 9) {
@@ -32,7 +35,12 @@ unsigned char tobcd(unsigned char in)
     return bcd_work;
 }
 
-unsigned char unbcd(unsigned char in)
+/**
+ * @brief Convert a binary coded decimal (BCD) value to binary
+ * @param in Input BCD value
+ * @return unsigned char Decimal value
+ */
+uint8_t unbcd(uint8_t in)
 {
     bcd_work = 0;
     while (in & 0xf0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,5 +11,6 @@ function(TEST NAME)
     endif()
 endfunction()
 
+TEST(test-fileio)
 TEST(test-memory)
 TEST(test-integer-size)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,5 +12,6 @@ function(TEST NAME)
 endfunction()
 
 TEST(test-fileio)
-TEST(test-memory)
 TEST(test-integer-size)
+TEST(test-memory)
+TEST(test-time)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_program(XEMU NAMES xmega65 xmega65.native)
-set(XEMU_ARGS "-besure -headless -sleepless -testing")
+set(XEMU_ARGS "-headless -sleepless -testing -model 3")
 
 function(TEST NAME)
     add_executable(${NAME} ${NAME}.c)

--- a/tests/test-fileio.c
+++ b/tests/test-fileio.c
@@ -9,17 +9,8 @@
  */
 #include <mega65/memory.h>
 #include <mega65/fileio.h>
+#include <mega65/tests.h>
 #include <stdlib.h>
-
-#define XEMU_CONTROL 0xD6CF
-#define XEMU_QUIT 0x42
-
-void xemu_exit(int exit_code)
-{
-    POKE(XEMU_CONTROL, (uint8_t)exit_code);
-    POKE(XEMU_CONTROL, XEMU_QUIT);
-    exit(exit_code);
-}
 
 #define assert_eq(A, B)                                                        \
     if (A != B)                                                                \

--- a/tests/test-fileio.c
+++ b/tests/test-fileio.c
@@ -1,0 +1,77 @@
+/**
+ * Tests for fileio.h for loading CHARROM.M65 from the SD card
+ *
+ * This can be run in Xemu in testing mode with e.g.
+ *
+ *     xmega65 -testing -headless -sleepless -prg test-fileio.prg
+ *
+ * If a test fails, Xemu exits with a non-zero return code.
+ */
+#include <mega65/memory.h>
+#include <mega65/fileio.h>
+#include <stdlib.h>
+
+#define XEMU_CONTROL 0xD6CF
+#define XEMU_QUIT 0x42
+
+void xemu_exit(int exit_code)
+{
+    POKE(XEMU_CONTROL, (uint8_t)exit_code);
+    POKE(XEMU_CONTROL, XEMU_QUIT);
+    exit(exit_code);
+}
+
+#define assert_eq(A, B)                                                        \
+    if (A != B)                                                                \
+    xemu_exit(EXIT_FAILURE)
+
+// Input file on SD card: CHARROM.M65
+char filename[11 + 1] = { 0x63, 0x68, 0x61, 0x72, 0x72, 0x6f, 0x6d, 0x2e, 0x6d,
+    0x36, 0x35, 0x00 };
+uint8_t file;
+uint8_t buffer[512];
+size_t num_bytes_read;
+
+int main(void)
+{
+    // Tests run in C64 mode so we need to enable mega65
+    mega65_io_enable();
+
+    // Good practice
+    closeall();
+    chdirroot();
+
+    // Check open status
+    file = open(filename);
+    if (file == 0xff) {
+        xemu_exit(EXIT_FAILURE);
+    }
+
+    // Read single 512 byte chunk
+    num_bytes_read = read512(buffer);
+    assert_eq(num_bytes_read, 512);
+
+    // Check first two bytes of chunk
+    assert_eq(buffer[0], 0x3c);
+    assert_eq(buffer[1], 0x66);
+
+    // Check last two bytes of chunk
+    assert_eq(buffer[510], 0x18);
+    assert_eq(buffer[511], 0x00);
+
+    // The size of CHARROM is 8 x 512 = 4096 bytes; let's read until EOF
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 512);
+    assert_eq(read512(buffer), 0);
+
+    // This has no effect on the test, but let's call anyway
+    close(file);
+    closeall();
+
+    xemu_exit(EXIT_SUCCESS);
+}

--- a/tests/test-fileio.c
+++ b/tests/test-fileio.c
@@ -20,6 +20,7 @@
 char filename[11 + 1] = { 0x63, 0x68, 0x61, 0x72, 0x72, 0x6f, 0x6d, 0x2e, 0x6d,
     0x36, 0x35, 0x00 };
 uint8_t file;
+uint8_t error;
 uint8_t buffer[512];
 size_t num_bytes_read;
 
@@ -30,7 +31,7 @@ int main(void)
 
     // Good practice
     closeall();
-    chdirroot();
+    error = chdirroot();
 
     // Check open status
     file = open(filename);

--- a/tests/test-integer-size.c
+++ b/tests/test-integer-size.c
@@ -27,6 +27,8 @@ void xemu_exit(int exit_code)
 
 int main(void)
 {
+    mega65_io_enable();
+
     // Integer sizes
     assert_eq(sizeof(uint8_t), 1);
     assert_eq(sizeof(unsigned char), 1);
@@ -44,5 +46,6 @@ int main(void)
 
     assert_eq(INT16_MAX, 0x7FFF);
     assert_eq(INT32_MAX, 0x7FFFFFFF);
+
     xemu_exit(EXIT_SUCCESS);
 }

--- a/tests/test-integer-size.c
+++ b/tests/test-integer-size.c
@@ -8,18 +8,9 @@
  * If a test fails, xemu will exit with a non-zero return code.
  */
 #include <mega65/memory.h>
+#include <mega65/tests.h>
 #include <stdlib.h>
 #include <stdint.h>
-
-#define XEMU_CONTROL 0xD6CF
-#define XEMU_QUIT 0x42
-
-void xemu_exit(int exit_code)
-{
-    POKE(XEMU_CONTROL, (uint8_t)exit_code);
-    POKE(XEMU_CONTROL, XEMU_QUIT);
-    exit(exit_code);
-}
 
 #define assert_eq(A, B)                                                        \
     if (A != B)                                                                \

--- a/tests/test-memory.c
+++ b/tests/test-memory.c
@@ -26,6 +26,7 @@ void xemu_exit(int exit_code)
 
 int main(void)
 {
+    mega65_io_enable();
     // DMAGIC DMA list size
     assert_eq(sizeof(struct dmagic_dmalist), 20);
 

--- a/tests/test-memory.c
+++ b/tests/test-memory.c
@@ -8,17 +8,8 @@
  * If a test fails, xemu will exit with a non-zero return code.
  */
 #include <mega65/memory.h>
+#include <mega65/tests.h>
 #include <stdlib.h>
-
-#define XEMU_CONTROL 0xD6CF
-#define XEMU_QUIT 0x42
-
-void xemu_exit(int exit_code)
-{
-    POKE(XEMU_CONTROL, (uint8_t)exit_code);
-    POKE(XEMU_CONTROL, XEMU_QUIT);
-    exit(exit_code);
-}
 
 #define assert_eq(A, B)                                                        \
     if (A != B)                                                                \

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -26,7 +26,6 @@ int main(void)
 
     getrtc(&tm);
 
-    assert_eq(detect_target(), TARGET_EMULATION);
     assert_eq(tm.tm_year + 1900 >= 2000, 1);
     assert_eq(tm.tm_mon < 12, 1);
     assert_eq(tm.tm_mday > 0, 1);

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -1,0 +1,41 @@
+/**
+ * Tests for time.h
+ *
+ * This can be run in Xemu in testing mode with e.g.
+ *
+ *     xmega65 -testing -headless -sleepless -prg test-time.prg
+ *
+ * If a test fails, Xemu exits with a non-zero return code.
+ */
+#include <mega65/memory.h>
+#include <mega65/time.h>
+#include <mega65/tests.h>
+#include <mega65/targets.h>
+#include <stdlib.h>
+
+#define assert_eq(A, B)                                                        \
+    if (A != B)                                                                \
+    xemu_exit(EXIT_FAILURE)
+
+struct m65_tm tm;
+
+int main(void)
+{
+    // Tests run in C64 mode so we need to enable mega65
+    mega65_io_enable();
+
+    getrtc(&tm);
+
+    assert_eq(detect_target(), TARGET_EMULATION);
+    assert_eq(tm.tm_year + 1900 >= 2000, 1);
+    assert_eq(tm.tm_mon < 12, 1);
+    assert_eq(tm.tm_mday > 0, 1);
+    assert_eq(tm.tm_mday < 32, 1);
+    assert_eq(tm.tm_hour < 24, 1);
+    assert_eq(tm.tm_min < 60, 1);
+    assert_eq(tm.tm_sec < 61, 1);
+    assert_eq(tm.tm_wday < 7, 1);
+    assert_eq(tm.tm_yday < 366, 1);
+
+    xemu_exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
# Changes
- Fixed broken `fileio.s` assembly code for llvm-mos (see #34) by changing calling convention.
- Fixed broken `getrtc()` function when running on Xemu.
- Add doxygen comments to selected functions
- Some type refactoring towards stdlib types.
- Add `TARGET_EMULATION` for detecting Xemu.
- New `make test` target for the cc65 Makefile
- New tests: `test-fileio` and `test-time`. Running looks something like this and passes on both cc65 and clang:
~~~ console
Running tests...
Test project /Users/mikael/github/mega65-libc/build
    Start 1: test-fileio
1/4 Test #1: test-fileio ......................   Passed    0.85 sec
    Start 2: test-integer-size
2/4 Test #2: test-integer-size ................   Passed    0.84 sec
    Start 3: test-memory
3/4 Test #3: test-memory ......................   Passed    0.84 sec
    Start 4: test-time
4/4 Test #4: test-time ........................   Passed    0.84 sec

100% tests passed, 0 tests failed out of 4
~~~

# CC65 vs. Clang file size

Clang generated output is significantly smaller:

File                  | CC65 | Clang
--------------------- | ---- | ----
test-fileio.prg       | 3706 | 743
test-integer-size.prg | 3152 | 135
test-memory.prg       | 3782 | 1203
test-time.prg         | 4822 | 1036

And apologies for this rather large PR; it should have been split into smaller pieces.

