### PR TITLE
Fix clobber lists for inline asm with clang

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -18,7 +18,7 @@ void debug_msg(char* msg)
                      "clv\n"
                      :           /* no output operands */
                      : "a"(*msg) /* input operands */
-                     : "a" /* clobber list */);
+                     : "v" /* clobber list */);
 #endif
         msg++;
     }
@@ -40,6 +40,6 @@ void debug_msg(char* msg)
                  "ldz #0\n"
                  : /* no output operands */
                  : /* no input operands*/
-                 : "a" /* clobber list */);
+                 : "a", "v" /* clobber list */);
 #endif
 }

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -222,7 +222,7 @@ unsigned char fc_nyblswap(unsigned char in) // oh why?!
                  "adc #$80\n"
                  "rol a\n"
                  "st%0" ::"a"(swp)
-                 : "a");
+                 : "c", "v");
 #else
 #pragma GCC warning "fc_nyblswap() is not implemented for this compiler"
 #endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -64,16 +64,16 @@ void unit_test_report(
 #else
     asm volatile("st%0 $D643\n"
                  "clv" ::"a"((uint8_t)(issue & 0xff))
-                 : "a");
+                 : "v");
     asm volatile("st%0 $D643\n"
                  "clv" ::"a"((uint8_t)(issue >> 8))
-                 : "a");
+                 : "v");
     asm volatile("st%0 $D643\n"
                  "clv" ::"a"(sub)
-                 : "a");
+                 : "v");
     asm volatile("st%0 $D643\n"
                  "clv" ::"a"(status)
-                 : "a");
+                 : "v");
 #endif
 }
 
@@ -93,7 +93,7 @@ void _unit_test_msg(char* msg, char cmd)
 #else
         asm volatile("st%0 $D643\n"
                      "clv" ::"a"(*current)
-                     : "a");
+                     : "v");
 #endif
         current++;
     }
@@ -106,7 +106,7 @@ void _unit_test_msg(char* msg, char cmd)
     asm volatile("lda #92\n"
                  "sta $D643\n"
                  "clv" ::
-                     : "a");
+                     : "a", "v");
 #endif
 }
 


### PR DESCRIPTION
Fix compilation with newer versions of llvm that detects a bug in inline asm clobber lists.