### PR TITLE
Prevent race condition on parallel build

### DIFF
--- a/Makefile_cc65
+++ b/Makefile_cc65
@@ -55,12 +55,14 @@ cleanall: clean
 src/cc65/%.o: src/cc65/%.s
 	$(CA65) -o $@ $<
 
-src/%.o: src/%.c
+src/%.o: src/%.c | work
+	$(CC65) $(CFLAGS) -o work/$*.s $<
+	$(CA65) -o $@ work/$*.s
+
+work:
 	@if [[ ! -d work ]]; then \
 		mkdir work; \
 	fi
-	$(CC65) $(CFLAGS) -o work/$*.s $<
-	$(CA65) -o $@ work/$*.s
 
 # Unit tests using Xemu in "testing" mode
 #


### PR DESCRIPTION
Two or more threads could all at the same time test that the "work" directory did not exist and then each proceed to create it, with all but one failing.  By making it an ordering dependency, this is prevented from happening.

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [x] using the CC65 compiler
  - [x] using the LLVM/Clang compiler
- [x] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [x] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [GNU Lesser General Public License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository

Note:  I did not change any code, just the `Makefile`.  I can't run `make test` currently because I don't have `xmega65`.  Getting that to run is probably a separate adventure.  :smile: