### PR TITLE
Remove invalid asm clobbers (fixes compilation errors with llvm-mos main branch)

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -18,7 +18,7 @@ void debug_msg(char* msg)
                      "clv\n"
                      :           /* no output operands */
                      : "a"(*msg) /* input operands */
-                     : "a" /* clobber list */);
+                     : /* clobber list */);
 #endif
         msg++;
     }

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -221,8 +221,8 @@ unsigned char fc_nyblswap(unsigned char in) // oh why?!
                  "asl a\n"
                  "adc #$80\n"
                  "rol a\n"
-                 "st%0" ::"a"(swp)
-                 : "a");
+                 "st%0"
+                 : "+a"(swp));
 #else
 #pragma GCC warning "fc_nyblswap() is not implemented for this compiler"
 #endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -63,17 +63,13 @@ void unit_test_report(
     __asm__("CLV");
 #else
     asm volatile("st%0 $D643\n"
-                 "clv" ::"a"((uint8_t)(issue & 0xff))
-                 : "a");
+                 "clv" ::"a"((uint8_t)(issue & 0xff)));
     asm volatile("st%0 $D643\n"
-                 "clv" ::"a"((uint8_t)(issue >> 8))
-                 : "a");
+                 "clv" ::"a"((uint8_t)(issue >> 8)));
     asm volatile("st%0 $D643\n"
-                 "clv" ::"a"(sub)
-                 : "a");
+                 "clv" ::"a"(sub));
     asm volatile("st%0 $D643\n"
-                 "clv" ::"a"(status)
-                 : "a");
+                 "clv" ::"a"(status));
 #endif
 }
 
@@ -92,8 +88,7 @@ void _unit_test_msg(char* msg, char cmd)
         __asm__("CLV");
 #else
         asm volatile("st%0 $D643\n"
-                     "clv" ::"a"(*current)
-                     : "a");
+                     "clv" ::"a"(*current));
 #endif
         current++;
     }


### PR DESCRIPTION
An asm clobber is not allowed to specify a register used as an input or output.  In the case of the debug asms which use "a" for input, the accumulator is never actually clobbered by the asm body, so just remove it from the clobber list.  In the case of fc_nyblswap, the accumulator is used as both input and output, so declare it as such instead of as a clobber.

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [x] using the CC65 compiler
  - [x] using the LLVM/Clang compiler
- [x] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [x] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [GNU Lesser General Public License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository
