### PR TITLE
Add missing fcio functions to LLVM-MOS build

### DIFF
--- a/src/fcio.c
+++ b/src/fcio.c
@@ -105,9 +105,6 @@ int gBottomBorder;
 bool csrflag; // cursor on/off
 bool autoCR;
 
-#ifdef __clang__
-#pragma GCC warning "readExt() is not implemented for clang yet"
-#else
 unsigned int readExt(FILE* inFile, himemPtr addr, byte skipCBMAddressBytes)
 {
 
@@ -133,11 +130,7 @@ unsigned int readExt(FILE* inFile, himemPtr addr, byte skipCBMAddressBytes)
 
     return overallRead;
 }
-#endif
 
-#ifdef __clang__
-#pragma GCC warning "loadExt() is not implemented for clang yet"
-#else
 unsigned int loadExt(char* filename, himemPtr addr, byte skipCBMAddressBytes)
 {
 
@@ -154,7 +147,6 @@ unsigned int loadExt(char* filename, himemPtr addr, byte skipCBMAddressBytes)
 
     return readBytes;
 }
-#endif
 
 void fc_loadReservedBitmap(char* name)
 {
@@ -221,8 +213,8 @@ unsigned char fc_nyblswap(unsigned char in) // oh why?!
                  "asl a\n"
                  "adc #$80\n"
                  "rol a\n"
-                 "st%0" ::"a"(swp)
-                 : "a");
+                 "st%0"
+                 : "+a"(swp));
 #else
 #pragma GCC warning "fc_nyblswap() is not implemented for this compiler"
 #endif
@@ -510,9 +502,6 @@ void fc_addGraphicsRect(
     }
 }
 
-#ifdef __clang__
-#pragma GCC warning "fc_loadFCI() is not implemented for clang yet"
-#else
 fciInfo* fc_loadFCI(char* filename, himemPtr address, himemPtr paletteAddress)
 {
     static byte numColumns, numRows, lastColourIndex;
@@ -598,7 +587,6 @@ fciInfo* fc_loadFCI(char* filename, himemPtr address, himemPtr paletteAddress)
 
     return info;
 }
-#endif
 
 void fc_zeroPalette(byte reservedSysPalette)
 {
@@ -961,9 +949,6 @@ char fc_getkey(void)
     return fc_cgetc();
 }
 
-#ifdef __clang__
-#pragma GCC warning "fc_getnum() is not implemented for clang yet"
-#else
 int fc_getnum(byte maxlen)
 {
     int res;
@@ -973,7 +958,6 @@ int fc_getnum(byte maxlen)
     free(inptr);
     return res;
 }
-#endif
 
 char* fc_input(byte maxlen)
 {


### PR DESCRIPTION
LLVM-MOS [now has stdio support](https://github.com/llvm-mos/llvm-mos-sdk/releases/tag/v17.1.0) which enables the missing features in fcio on clang. Note that llvm-mos stdio is **largely untested** on the mega65 target and things might not work. This should eventually be fixed in llvm-mos-sdk, not in mega65-libc.

~~This fails on CI due to missing asm clobber fix which has not made it into `master` branch.~~

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [x] using the CC65 compiler
  - [x] using the LLVM/Clang compiler
- [x] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [x] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [GNU Lesser General Public License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository
