### PR TITLE
Fix screen code naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Simple C library for the MEGA65
    ~~~sh
    cd mega65-libc
    cmake -DCMAKE_PREFIX_PATH=$HOME/llvm-mos -B build
+   cd build
    make
    make test # if `xmega65` (Xemu) was in your path when running cmake
    ~~~

--- a/include/mega65/fcio.h
+++ b/include/mega65/fcio.h
@@ -526,4 +526,21 @@ void fc_plotExtChar(byte x, byte y, byte c);
  */
 void fc_plotScreenChar(byte x, byte y, byte c, byte color, byte exAttr);
 
+/**
+ * @deprecated The function name is misleading as the supplied character code
+ *             is expected to be a screen character code, not a PETSCII code.
+ *             Use @ref fc_plotScreenChar(byte, byte, byte, byte, byte) instead.
+ * @brief plot screencode character
+ *
+ * @param x screen column
+ * @param y screen row
+ * @param c character code
+ * @param color character colour
+ * @param exAttr extended attributes
+ */
+#ifdef __clang__
+[[deprecated("Use fc_plotScreenChar() instead.")]]
+#endif
+void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr);
+
 #endif // __MEGA65_FCIO_H

--- a/include/mega65/fcio.h
+++ b/include/mega65/fcio.h
@@ -516,7 +516,7 @@ fciInfo* fc_displayFCIFile(char* filename, byte x0, byte y0);
 void fc_plotExtChar(byte x, byte y, byte c);
 
 /**
- * @brief plot petscii character
+ * @brief plot screencode character
  *
  * @param x screen column
  * @param y screen row
@@ -524,6 +524,6 @@ void fc_plotExtChar(byte x, byte y, byte c);
  * @param color character colour
  * @param exAttr extended attributes
  */
-void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr);
+void fc_plotScreenChar(byte x, byte y, byte c, byte color, byte exAttr);
 
 #endif // __MEGA65_FCIO_H

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -341,7 +341,7 @@ himemPtr fc_allocPalMem(word size)
     return 0;
 }
 
-char asciiToPetscii(byte c)
+char asciiToScreencode(byte c)
 {
     // TODO: could be made much faster with translation table
     if (c == '_') {
@@ -741,7 +741,7 @@ void cr(void)
     }
 }
 
-void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr)
+void fc_plotScreenChar(byte x, byte y, byte c, byte color, byte exAttr)
 {
     word adrOffset;
     adrOffset = (x * 2) + (y * 2 * gScreenColumns);
@@ -781,9 +781,9 @@ void fc_putc(char c)
         return;
     }
 
-    out = asciiToPetscii(c);
+    out = asciiToScreencode(c);
 
-    fc_plotPetsciiChar(gCurrentWin->xc + gCurrentWin->x0,
+    fc_plotScreenChar(gCurrentWin->xc + gCurrentWin->x0,
         gCurrentWin->yc + gCurrentWin->y0, out, gCurrentWin->textcolor,
         gCurrentWin->extAttributes);
     gCurrentWin->xc++;
@@ -800,7 +800,7 @@ void fc_putc(char c)
     }
 
     if (csrflag) {
-        fc_plotPetsciiChar(gCurrentWin->xc + gCurrentWin->x0,
+        fc_plotScreenChar(gCurrentWin->xc + gCurrentWin->x0,
             gCurrentWin->yc + gCurrentWin->y0, CURSOR_CHARACTER,
             gCurrentWin->textcolor, 16);
     }
@@ -849,7 +849,7 @@ void fc_cursor(byte onoff)
 {
     csrflag = onoff;
 
-    fc_plotPetsciiChar(gCurrentWin->xc + gCurrentWin->x0,
+    fc_plotScreenChar(gCurrentWin->xc + gCurrentWin->x0,
         gCurrentWin->yc + gCurrentWin->y0, (csrflag ? CURSOR_CHARACTER : 32),
         gCurrentWin->textcolor, (csrflag ? 16 : 0));
 }

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -359,14 +359,6 @@ char asciiToScreencode(byte c)
     return (char)c;
 }
 
-#ifdef __llvm__
-[[deprecated("Use asciiToScreencode() instead.")]]
-#endif
-char asciiToPetsciicode(byte c)
-{
-    return asciiToScreencode(c);
-}
-
 #ifdef __clang__
 void adjustBorders(byte extraRows, __attribute__((unused)) byte extraColumns)
 #else
@@ -757,6 +749,11 @@ void fc_plotScreenChar(byte x, byte y, byte c, byte color, byte exAttr)
     lpoke(gFcioConfig->screenBase + adrOffset + 1, 0);
     lpoke(gFcioConfig->colourBase + adrOffset + 1, color | exAttr);
     lpoke(gFcioConfig->colourBase + adrOffset, 0);
+}
+
+void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr)
+{
+    fc_plotScreenChar(x, y, c, color, exAttr);
 }
 
 byte fc_wherex(void)

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -356,7 +356,15 @@ char asciiToScreencode(byte c)
     if (c >= 192) {
         return c - 128;
     }
-    return c;
+    return (char)c;
+}
+
+#ifdef __llvm__
+[[deprecated("Use asciiToScreencode() instead.")]]
+#endif
+char asciiToPetsciicode(byte c)
+{
+    return asciiToScreencode(c);
 }
 
 #ifdef __clang__
@@ -781,7 +789,7 @@ void fc_putc(char c)
         return;
     }
 
-    out = asciiToScreencode(c);
+    out = asciiToScreencode((byte)c);
 
     fc_plotScreenChar(gCurrentWin->xc + gCurrentWin->x0,
         gCurrentWin->yc + gCurrentWin->y0, out, gCurrentWin->textcolor,


### PR DESCRIPTION
## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [x] using the CC65 compiler
  - [x] using the LLVM/Clang compiler
- [x] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [x] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository
