### PR TITLE
Fix fc_nyblswap on LLVM

### DIFF
--- a/src/fcio.c
+++ b/src/fcio.c
@@ -191,11 +191,11 @@ void fc_init(
     fc_textcolor(COLOR_GREEN);
 }
 
-static unsigned char swp;
 unsigned char fc_nyblswap(unsigned char in) // oh why?!
 {
-    swp = in;
 #ifdef __CC65__
+    static unsigned char swp;
+    swp = in;
     __asm__("lda %v", swp);
     __asm__("asl  a");
     __asm__("adc  #$80");
@@ -204,21 +204,20 @@ unsigned char fc_nyblswap(unsigned char in) // oh why?!
     __asm__("adc  #$80");
     __asm__("rol  a");
     __asm__("sta %v", swp);
+    return swp;
 #elif defined(__clang__)
-#pragma GCC warning "LLVM assembly needs to be checked in fc_nyblswap()"
-    asm volatile("ld%0\n"
-                 "asl a\n"
+    asm volatile("asl a\n"
                  "adc #$80\n"
                  "rol a\n"
                  "asl a\n"
                  "adc #$80\n"
                  "rol a\n"
-                 "st%0"
-                 : "+a"(swp));
+                 : "+a"(in));
+    return in;
 #else
 #pragma GCC warning "fc_nyblswap() is not implemented for this compiler"
+    return in;
 #endif
-    return swp;
 }
 
 void fc_flash(byte f)


### PR DESCRIPTION
With a constraint "a", %0 will expand to "A" in the asm, meaning "ld%0" will become "ldA" without any address.  But since we have constrained the operand to already be in A, there is no need to add any load or store instructions anyway, so just remove them.

Also the global variable "swp" is not needed either, so remove that as well when using LLVM.

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [x] using the CC65 compiler
  - [x] using the LLVM/Clang compiler
- [x] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [x] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository

Also tested palette loading with xemu, worked fine both with cc65 and llvm-mos.
Without this fix linking fails on llvm-mos with:
```
ld.lld: error: ld-temp.o <inline asm>:1:2: too few operands for instruction
        ldA
        ^
ld.lld: error: ld-temp.o <inline asm>:8:1: too few operands for instruction
stA
^
ld.lld: error: ld-temp.o <inline asm>:1:2: too few operands for instruction
        ldA
        ^
ld.lld: error: ld-temp.o <inline asm>:8:1: too few operands for instruction
stA
^
ld.lld: error: ld-temp.o <inline asm>:1:2: too few operands for instruction
        ldA
        ^
ld.lld: error: ld-temp.o <inline asm>:8:1: too few operands for instruction
stA
^
mos-mega65-clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
```