### PR TITLE
Fixes file reference in examples

### DIFF
--- a/tests/test-math.c
+++ b/tests/test-math.c
@@ -1,5 +1,5 @@
 /**
- * @example test-integer-math.c
+ * @example test-math.c
  *
  * Tests for math functions
  *


### PR DESCRIPTION
Doxygen would complain about not being able to find test-integer-math.c. I suppose the file was renamed at some point, without adjusting the respective comment.

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [x] using the CC65 compiler
  - [x] using the LLVM/Clang compiler
- [x] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [x] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository
- [x] I also agree to the Apache 2 license
