### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Simple C library for the MEGA65
    make test # if `xmega65` (Xemu) was in your path when running cmake
    ~~~
 
-Installed artifacts should be made visible to cmake's package search, e.g. by adding their path to CMAKE_PREFIX_PATH.
+Location of installed mega65-libc should be included into cmake's package search paths, e.g. by adding its path to the ```CMAKE_PREFIX_PATH```.
 
 #### Dependent projects
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Simple C library for the MEGA65
    cd mega65-libc
    cmake -DCMAKE_PREFIX_PATH=$HOME/llvm-mos -B build
    make
+   make install # install library files
    make test # if `xmega65` (Xemu) was in your path when running cmake
    ~~~
+
+Installed artifacts should be made visible to cmake's package search, e.g. by adding their path to CMAKE_PREFIX_PATH.
 
 #### Dependent projects
 


### PR DESCRIPTION
Added information about necessary "make install" step. From my experience, on Win 11 without having the lib installed and its target location referred from the custom project (C:/Program Files (x86)/mega65libc) cmake configuration would fail.

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [ ] using the CC65 compiler
  - [ ] using the LLVM/Clang compiler
- [ ] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [ ] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [x] I agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository
