### PR TITLE
Make lib usable with C++

### DIFF
--- a/include/mega65/conio.h
+++ b/include/mega65/conio.h
@@ -186,6 +186,11 @@
 #define CINPUT_NO_AUTOTRANSLATE 8
 #define CINPUT_ACCEPT_ALPHA CINPUT_ACCEPT_NUMERIC | CINPUT_ACCEPT_LETTER
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /*------------------------------------------------------------------------
   Public structs
   -----------------------------------------------------------------------*/
@@ -923,10 +928,10 @@ void fastcall cputnc(unsigned char count, unsigned char c);
 void cputhex(unsigned long n, unsigned char prec);
 
 /* \m65libsummary{cputdec}{Output a decimal number at current position}
-    \m65libsyntax    {void cputdec(unsigned long n, unsigned char padding, unsigned char
-   leadingZ)} \m65libparam     {n}{The number to write} \m65libparam
-   {padding}{The padding space to add before number} \m65libparam {leadingZ}{The
-   leading zeros to print}
+    \m65libsyntax    {void cputdec(unsigned long n, unsigned char padding,
+   unsigned char leadingZ)} \m65libparam     {n}{The number to write}
+   \m65libparam {padding}{The padding space to add before number} \m65libparam
+   {leadingZ}{The leading zeros to print}
 */
 /**
  * @brief Output a decimal number at current position
@@ -1196,5 +1201,9 @@ void flushkeybuf(void);
  */
 unsigned char cinput(
     unsigned char* buffer, unsigned char buflen, unsigned char flags);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif /* __MEGA65_CONIO_H */

--- a/include/mega65/debug.h
+++ b/include/mega65/debug.h
@@ -5,10 +5,19 @@
 #ifndef __MEGA65_DEBUG_H
 #define __MEGA65_DEBUG_H
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief Write debug message to serial monitor
  * @param msg Text message to write
  */
 void debug_msg(char* msg);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_DEBUG_H

--- a/include/mega65/dirent.h
+++ b/include/mega65/dirent.h
@@ -11,17 +11,24 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /// Open a directory
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-unsigned char opendir(void);
+unsigned char
+opendir(void);
 
 /// Read directory entry
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-struct m65_dirent* readdir(unsigned char);
+struct m65_dirent*
+readdir(unsigned char);
 
 /// Close directory entry
 #ifdef __clang__
@@ -37,5 +44,9 @@ struct m65_dirent {
     uint16_t d_type;   //!< File type
     char d_name[256];  //!< Filename string of entry
 };
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_DIRENT_H

--- a/include/mega65/fcio.h
+++ b/include/mega65/fcio.h
@@ -39,6 +39,11 @@
 #define COLOUR_GREY3 15      //!< Grey3 color
 #define COLOUR_LIGHTGREY 15  //!< Light grey color
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 #ifndef byte
 typedef unsigned char byte;
 #endif
@@ -542,5 +547,9 @@ void fc_plotScreenChar(byte x, byte y, byte c, byte color, byte exAttr);
 [[deprecated("Use fc_plotScreenChar() instead.")]]
 #endif
 void fc_plotPetsciiChar(byte x, byte y, byte c, byte color, byte exAttr);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_FCIO_H

--- a/include/mega65/fileio.h
+++ b/include/mega65/fileio.h
@@ -12,6 +12,11 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 #ifdef __clang__
 __attribute__((leaf))
 #endif
@@ -42,7 +47,8 @@ void close(uint8_t fd);
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-uint8_t open(char* filename);
+uint8_t
+open(char* filename);
 
 /**
  * @brief Read up to 512 bytes from file
@@ -52,7 +58,8 @@ uint8_t open(char* filename);
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-size_t read512(uint8_t* buffer);
+size_t
+read512(uint8_t* buffer);
 
 /**
  * @brief Change working directory
@@ -63,7 +70,8 @@ size_t read512(uint8_t* buffer);
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-uint8_t chdir(char* filename);
+uint8_t
+chdir(char* filename);
 
 /**
  * @brief Change working directory to the root directory
@@ -72,7 +80,8 @@ uint8_t chdir(char* filename);
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-uint8_t chdirroot(void);
+uint8_t
+chdirroot(void);
 
 /**
  * @brief Struct for holding version information of the hypervisor
@@ -95,5 +104,9 @@ struct hyppo_version {
 __attribute__((leaf))
 #endif
 void gethyppoversion(struct hyppo_version* version);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_FILEIO_H

--- a/include/mega65/hal.h
+++ b/include/mega65/hal.h
@@ -7,10 +7,19 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief Sleep for the given number of microseconds
  * @param micros Microseconds to sleep
  */
 void usleep(uint32_t micros);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_HAL_H

--- a/include/mega65/math.h
+++ b/include/mega65/math.h
@@ -43,6 +43,11 @@ SOFTWARE.
 #define MULTINB 0xD774
 #define MULTOUT 0xD778
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief Multiply two 32-bit unsigned integers and return 32-bit value
  * @param a First 32-bit value
@@ -90,6 +95,10 @@ inline uint8_t umul8(const uint8_t a, const uint8_t b)
 }
 #else
 uint8_t umul8(const uint8_t a, const uint8_t b);
+#endif
+
+#ifdef __cplusplus
+} // End of extern "C"
 #endif
 
 #endif // __MEGA65_MATH_H

--- a/include/mega65/memory.h
+++ b/include/mega65/memory.h
@@ -22,6 +22,11 @@
 #define DMA_XYMOD_ADDR                                                         \
     0x03; //!< DMA XY MOD (bitmap rectangular) addressing mode (unimplemented)
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief DMA list structure
  */
@@ -70,14 +75,16 @@ void mega65_io_enable(void);
 #ifdef __clang__
 __attribute__((leaf))
 #endif
-uint8_t lpeek(uint32_t address);
+uint8_t
+lpeek(uint32_t address);
 
 #ifdef __llvm__
 /**
  * @brief Inlined version of `lpeek()`
  * @param ADDRESS 28-bit address; must be a compile-time constant.
  * @returns Value at address
- * @warning This function is experimental and may change/be removed in future versions
+ * @warning This function is experimental and may change/be removed in future
+ * versions
  */
 inline uint8_t lpeek_i(const uint32_t ADDRESS)
 {
@@ -172,6 +179,10 @@ void lfill_skip(
 #ifdef __clang__
 /// Peek eight bytes from the given address
 #define PEEK64(X) (*(volatile uint64_t*)(X))
+#endif
+
+#ifdef __cplusplus
+} // End of extern "C"
 #endif
 
 #endif // __MEGA65_MEMORY_H

--- a/include/mega65/mouse.h
+++ b/include/mega65/mouse.h
@@ -27,6 +27,11 @@
 #ifndef __MEGA65_MOUSE_H
 #define __MEGA65_MOUSE_H
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 void mouse_warp_to(unsigned short x, unsigned short y);
 void mouse_update_position(unsigned short* mx, unsigned short* my);
 void mouse_update_pointer(void);
@@ -35,5 +40,9 @@ void mouse_clip_position(void);
 void mouse_bind_to_sprite(unsigned char sprite_num);
 void mouse_set_bounding_box(
     unsigned short x1, unsigned short y1, unsigned short x2, unsigned short y2);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_MOUSE_H

--- a/include/mega65/random.h
+++ b/include/mega65/random.h
@@ -12,6 +12,11 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief 32-bit random number using MEGA65 hardware entropy
  * @param range Maximum value in range
@@ -53,5 +58,9 @@ uint16_t rand16(uint16_t range);
  * @param range Maximum value in range
  */
 uint32_t rand32(uint32_t range);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_RANDOM_H

--- a/include/mega65/sdcard.h
+++ b/include/mega65/sdcard.h
@@ -7,6 +7,11 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 extern uint8_t sector_buffer[512];
 
 void mega65_clear_sector_buffer(void);
@@ -19,5 +24,9 @@ uint8_t mega65_sdcard_readsector(const uint32_t sector_number);
 uint8_t mega65_sdcard_writesector(const uint32_t sector_number);
 void mega65_sdcard_erase(
     const uint32_t first_sector, const uint32_t last_sector);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_SDCARD_H

--- a/include/mega65/targets.h
+++ b/include/mega65/targets.h
@@ -8,6 +8,11 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 enum
 #ifdef __clang__
     : uint8_t
@@ -37,5 +42,9 @@ enum
  * @brief Detect target
  */
 uint8_t detect_target(void);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_TARGETS_H

--- a/include/mega65/tests.h
+++ b/include/mega65/tests.h
@@ -20,6 +20,11 @@
 #define XEMU_CONTROL 0xD6CF
 #define XEMU_QUIT 0x42 //!< Command to make Xemu quit
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief Quits Xemu with given exit code
  * @param exit_code Exit code passed to Xemu, e.g. EXIT_SUCCESS or EXIT_FAILURE
@@ -216,5 +221,9 @@ void unit_test_print(uint8_t x, uint8_t y, uint8_t colour, char* msg);
  */
 void unit_test_read_pixel(
     short x, short y, uint8_t* red, uint8_t* green, uint8_t* blue);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_TESTS_H

--- a/include/mega65/time.h
+++ b/include/mega65/time.h
@@ -11,6 +11,11 @@
 #ifndef __MEGA65_TIME_H
 #define __MEGA65_TIME_H
 
+#ifdef __cplusplus
+// Being compiled by a C++ compiler, inhibit name mangling
+extern "C" {
+#endif
+
 /**
  * @brief Real-time clock structure
  */
@@ -34,5 +39,9 @@ struct m65_tm {
 void getrtc(struct m65_tm* tm);
 /// Set real-time clock
 void setrtc(struct m65_tm* tm);
+
+#ifdef __cplusplus
+} // End of extern "C"
+#endif
 
 #endif // __MEGA65_TIME_H


### PR DESCRIPTION
Add 'extern "C"' to function definitions to inhibit name mangling if used in C++ sources.
Closes #63.

## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [ ] using the CC65 compiler
  - [ ] using the LLVM/Clang compiler
- [ ] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [X] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [X] I agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository

I did build with CC65. I can building with Clang and run the tests after setting up my environment for that(if I find the time). But I could use the lib with the changes in my application development environment. I have no such environment setup for this lib, yet.

I did not change comments, so I did not tick that item off.
