### PR TITLE
Fix broken cinput

### DIFF
--- a/src/conio.c
+++ b/src/conio.c
@@ -714,7 +714,8 @@ unsigned char cinput(
     }
 
     while (1) {
-        cputsxy(sx, sy, buffer);
+        if (strlen(buffer) != 0)  
+            cputsxy(sx, sy, buffer);
         blink(1);
         cputc(224);
         blink(0);


### PR DESCRIPTION
## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [ ] using the CC65 compiler
  - [ ] using the LLVM/Clang compiler
- [ ] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [ ] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [ ] I agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository
