### PR TITLE
Correctly handle  0 length strings in conio

### DIFF
--- a/include/mega65/conio.h
+++ b/include/mega65/conio.h
@@ -914,7 +914,8 @@ void fastcall cputs(const unsigned char* s);
  * @param y The Y coordinate where string will be printed
  * @param s An array of screen codes to print. Must have non-zero length.
  * @remarks This function works with screen codes only. To output ordinary
- * @warning Undefined behavior if `s` has zero length.
+ * ASCII/PETSCII strings, use the "pcputsxy" macro. No pointer check is
+ * performed.  If s is null or invalid, behavior is undefined.
  */
 void cputsxy(unsigned char x, unsigned char y, const unsigned char* s);
 

--- a/include/mega65/conio.h
+++ b/include/mega65/conio.h
@@ -946,7 +946,6 @@ void cputcxy(unsigned char x, unsigned char y, unsigned char c);
  * @param y The Y coordinate where character will be printed
  * @param count The number of characters to output. Must be larger than zero.
  * @param c The screen code of the characters to print
- * @warning Undefined behavior if `count` is zero.
  */
 void cputncxy(
     unsigned char x, unsigned char y, unsigned char count, unsigned char c);

--- a/src/conio.c
+++ b/src/conio.c
@@ -596,9 +596,9 @@ void cputncxy(
         const unsigned int offset = (y * (unsigned int)g_curScreenW) + x;
         lfill(SCREEN_RAM_BASE + offset, c, count);
         lfill(COLOR_RAM_BASE + offset, g_curTextColor, count);
-        g_curY = y + ((x + count) / g_curScreenW);
-        g_curX = (x + count) % g_curScreenW;
     }
+    g_curY = y + ((x + count) / g_curScreenW);
+    g_curX = (x + count) % g_curScreenW;
 }
 
 void fillrect(const RECT* rc, unsigned char ch, unsigned char col)

--- a/src/conio.c
+++ b/src/conio.c
@@ -571,11 +571,13 @@ void cputs(const unsigned char* s)
 void cputsxy(unsigned char x, unsigned char y, const unsigned char* s)
 {
     const unsigned char len = (unsigned char)strlen((const char*)s);
-    const unsigned int offset = (y * (unsigned int)g_curScreenW) + x;
-    lcopy((unsigned long)s, SCREEN_RAM_BASE + offset, len);
-    lfill(COLOR_RAM_BASE + offset, g_curTextColor, len);
-    g_curY = y + ((x + len) / g_curScreenW);
-    g_curX = (x + len) % g_curScreenW;
+    if (len > 0) {
+        const unsigned int offset = (y * (unsigned int)g_curScreenW) + x;
+        lcopy((unsigned long)s, SCREEN_RAM_BASE + offset, len);
+        lfill(COLOR_RAM_BASE + offset, g_curTextColor, len);
+        g_curY = y + ((x + len) / g_curScreenW);
+        g_curX = (x + len) % g_curScreenW;
+    }
 }
 
 void cputcxy(unsigned char x, unsigned char y, unsigned char c)
@@ -590,11 +592,13 @@ void cputcxy(unsigned char x, unsigned char y, unsigned char c)
 void cputncxy(
     unsigned char x, unsigned char y, unsigned char count, unsigned char c)
 {
-    const unsigned int offset = (y * (unsigned int)g_curScreenW) + x;
-    lfill(SCREEN_RAM_BASE + offset, c, count);
-    lfill(COLOR_RAM_BASE + offset, g_curTextColor, count);
-    g_curY = y + ((x + count) / g_curScreenW);
-    g_curX = (x + count) % g_curScreenW;
+    if (count > 0) {
+        const unsigned int offset = (y * (unsigned int)g_curScreenW) + x;
+        lfill(SCREEN_RAM_BASE + offset, c, count);
+        lfill(COLOR_RAM_BASE + offset, g_curTextColor, count);
+        g_curY = y + ((x + count) / g_curScreenW);
+        g_curX = (x + count) % g_curScreenW;
+    }
 }
 
 void fillrect(const RECT* rc, unsigned char ch, unsigned char col)

--- a/src/conio.c
+++ b/src/conio.c
@@ -718,8 +718,7 @@ unsigned char cinput(
     }
 
     while (1) {
-        if (strlen(buffer) != 0)  
-            cputsxy(sx, sy, buffer);
+        cputsxy(sx, sy, buffer);
         blink(1);
         cputc(224);
         blink(0);

--- a/src/conio.c
+++ b/src/conio.c
@@ -575,9 +575,9 @@ void cputsxy(unsigned char x, unsigned char y, const unsigned char* s)
         const unsigned int offset = (y * (unsigned int)g_curScreenW) + x;
         lcopy((unsigned long)s, SCREEN_RAM_BASE + offset, len);
         lfill(COLOR_RAM_BASE + offset, g_curTextColor, len);
-        g_curY = y + ((x + len) / g_curScreenW);
-        g_curX = (x + len) % g_curScreenW;
     }
+    g_curY = y + ((x + len) / g_curScreenW);
+    g_curX = (x + len) % g_curScreenW;
 }
 
 void cputcxy(unsigned char x, unsigned char y, unsigned char c)


### PR DESCRIPTION
## Checklist

Thanks a lot for your contribution!
Please tick off the following:

- Tests run successfully (i.e. `make test`)
  - [*] using the CC65 compiler
  - [* using the LLVM/Clang compiler
- [X] [Doxygen](https://www.doxygen.nl/index.html) style tags are used for public API
- [X] Source code is properly formatted; run e.g. `clang-format -i <file>`
- [XI agree to the [License](https://github.com/MEGA65/mega65-libc/blob/master/LICENSE) of this repository

* - Please note that there appears to be a single test failure however that may be due to my atypical Xemu usage.  It also is in an unrelated test. 

Also, I removed the undocumented behavior note on cputncxy for a zero length string. 0 length will now work as expected, eg: no output. 